### PR TITLE
Add OUT OF TREE building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,4 +85,18 @@ else()
 endif()
 # --- End of section ---
 
+if(BUILD_OUT_OF_TREE)
+    if(NOT LIB_OUT_DIR)
+        set(LIB_OUT_DIR "/lib/obs-plugins")
+    endif()
+    if(NOT DATA_OUT_DIR)
+        set(DATA_OUT_DIR "/share/obs/obs-plugins/${PROJECT_NAME}")
+    endif()
+    set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+    install(TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIB_OUT_DIR})
+    install(DIRECTORY data/locale
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${DATA_OUT_DIR})
+endif()
+
 setup_plugin_target(${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
This is needed to build the plugin using libobs-dev only, not inside of the obs-studio. Several plugins are providing out of tree building, and this is very important for Linux distributions.