### PR TITLE
Added code that will create config folder if one doesn't exist

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -893,10 +893,16 @@ void CountdownDockWidget::SaveSettings()
 	// obs_data_array_release(stop_to_time_countdown_hotkey_save_array);
 
 	char *file = obs_module_config_path(CONFIG);
-	obs_data_save_json(obsData, file);
+	if (!obs_data_save_json(obsData, file)) {
+		char *path = obs_module_config_path("");
+		if (path) {
+			os_mkdirs(path);
+			bfree(path);
+		}
+		obs_data_save_json(obsData, file);
+	}
 	obs_data_release(obsData);
 	bfree(file);
-
 	deleteLater();
 }
 


### PR DESCRIPTION
This change should address the issue where if a save folder doesn't exist for the plugin one is generated. This was causing issues where configuration of the app wouldn't be saved because when first installed there is no configuration folder setup to save to.