### PR TITLE
Fix - To Time Not Starting When Period Set To Zero

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16...3.21)
 
 # Change obs-plugintemplate to your plugin's name in a machine-readable format (e.g.:
 # obs-myawesomeplugin) and set
-project(obs-plugin-countdown VERSION 1.3.0)
+project(obs-plugin-countdown VERSION 1.3.1)
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
 # Replace `Your Name Here` with the name (yours or your organization's) you want to see as the

--- a/buildspec.json
+++ b/buildspec.json
@@ -82,5 +82,5 @@
         }
     },
     "name": "obs-plugin-countdown",
-    "version": "1.3.0"
+    "version": "1.3.1"
 }

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -324,9 +324,6 @@ void CountdownDockWidget::ToTimePlayButtonClicked()
 			      timeDifference.seconds,
 			      timeDifference.milliseconds);
 
-	// if (IsSetTimeZero(context))
-	// 	return;
-
 	ui->timeDisplay->display(context->time->toString("hh:mm:ss"));
 	StartTimerCounting(context);
 }

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -324,8 +324,8 @@ void CountdownDockWidget::ToTimePlayButtonClicked()
 			      timeDifference.seconds,
 			      timeDifference.milliseconds);
 
-	if (IsSetTimeZero(context))
-		return;
+	// if (IsSetTimeZero(context))
+	// 	return;
 
 	ui->timeDisplay->display(context->time->toString("hh:mm:ss"));
 	StartTimerCounting(context);


### PR DESCRIPTION
This fixes the bug where when you try to start the timer using the `time` tab it wont start if the `period` tab time is set to zero.

This closes issue #31 