### PR TITLE
ConvertTimeToDisplayString rewrite

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -521,26 +521,16 @@ QString CountdownDockWidget::ConvertTimeToDisplayString(QTime *timeToConvert)
 	int secondsState = ui->secondsCheckBox->checkState();
 
 	QString stringTime = "";
+	QString timeFormat = "";
 
-	if (hoursState && minutesState && secondsState) {
-		stringTime = timeToConvert->toString("hh:mm:ss");
-	} else if (!hoursState && minutesState && secondsState) {
-		stringTime = timeToConvert->toString("m:ss");
-	} else if (!hoursState && !minutesState && secondsState) {
-		stringTime = timeToConvert->toString("s");
-	} else if (!hoursState && minutesState && !secondsState) {
-		stringTime = timeToConvert->toString("mm");
-	} else if (hoursState && !minutesState && !secondsState) {
-		stringTime = timeToConvert->toString("h");
-	} else if (hoursState && !minutesState && secondsState) {
-		stringTime = timeToConvert->toString("h:ss");
-	} else if (hoursState && minutesState && !secondsState) {
-		stringTime = timeToConvert->toString("h:mm");
-	} else if (!hoursState && !minutesState && !secondsState) {
-		stringTime = "Nothing selected!";
-	}
+	timeFormat += hoursState ? "hh" : "";
+	timeFormat += (timeFormat != "" && minutesState) ? ":" : "";
+	timeFormat += minutesState ? "mm" : "";
+	timeFormat += (timeFormat != "" && secondsState) ? ":" : "";
+	timeFormat += secondsState ? "ss" : "";
+	timeFormat = timeFormat == "" ? "Nothing selected!" : timeFormat;
 
-	return stringTime;
+	return (timeFormat == "") ? "Nothing selected!" : timeToConvert->toString(timeFormat);
 }
 
 void CountdownDockWidget::UpdateTimeDisplay(QTime *time)

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -528,7 +528,6 @@ QString CountdownDockWidget::ConvertTimeToDisplayString(QTime *timeToConvert)
 	timeFormat += minutesState ? "mm" : "";
 	timeFormat += (timeFormat != "" && secondsState) ? ":" : "";
 	timeFormat += secondsState ? "ss" : "";
-	timeFormat = timeFormat == "" ? "Nothing selected!" : timeFormat;
 
 	return (timeFormat == "") ? "Nothing selected!" : timeToConvert->toString(timeFormat);
 }

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -520,7 +520,6 @@ QString CountdownDockWidget::ConvertTimeToDisplayString(QTime *timeToConvert)
 	int minutesState = ui->minutesCheckBox->checkState();
 	int secondsState = ui->secondsCheckBox->checkState();
 
-	QString stringTime = "";
 	QString timeFormat = "";
 
 	timeFormat += hoursState ? "hh" : "";

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -522,7 +522,7 @@ QString CountdownDockWidget::ConvertTimeToDisplayString(QTime *timeToConvert)
 
 	QString stringTime = "";
 
-	if (hoursState && minutesState & secondsState) {
+	if (hoursState && minutesState && secondsState) {
 		stringTime = timeToConvert->toString("hh:mm:ss");
 	} else if (!hoursState && minutesState && secondsState) {
 		stringTime = timeToConvert->toString("m:ss");


### PR DESCRIPTION
Removed extra complexity from method. Removed inconsistent output behavior (output will now always have a leading 0 if below 10). A checkbox option to display leading 0 or not is recommended