### PR TITLE
Fix macOS packaging CI failing

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -148,7 +148,7 @@ jobs:
           codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
           installerIdent: ${{ steps.codesign.outputs.installerIdent }}
           codesignTeam: ${{ steps.codesign.outputs.codesignTeam }}
-          notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
+          notarize: ${{ needs.check-event.outputs.notarize && fromJSON(needs.check-event.outputs.notarize) && steps.codesign.outputs.haveNotarizationUser && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
           codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -33,7 +33,7 @@
     },
     "platformConfig": {
         "macos": {
-            "bundleId": "com.example.obs-plugin-countdown"
+            "bundleId": "com.ashmanix.obs-plugin-countdown"
         }
     },
     "name": "obs-plugin-countdown",


### PR DESCRIPTION
A bundle name change and altering the notarise line in `build-project.yaml` due to action failing for macOS packaging. I also changed the bundle ID to a more relevant name.