### PR TITLE
Add Time Through Websocket

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -318,7 +318,79 @@ void CountdownDockWidget::ConfigureWebSocketConnection()
 		},
 		this);
 
+	obs_websocket_vendor_register_request(
+		vendor, "add_time", [](obs_data_t *request_data, obs_data_t *response_data,
+		   void *priv_data) {
+			CountdownDockWidget *self =
+				static_cast<CountdownDockWidget *>(priv_data);
+			UNUSED_PARAMETER(self);
+
+			const char* time_to_add = obs_data_get_string(request_data, "time_to_add");
+
+			if(time_to_add == nullptr || strlen(time_to_add) == 0) {
+				obs_data_set_bool(response_data, "success", false);
+				obs_data_set_string(response_data, "message", "time_to_add field is missing from request!");
+			} else {
+				obs_log(LOG_INFO, "Time to add: %s", time_to_add);
+				long long timeToAddInMillis = self->AddTimeToTimer(time_to_add, self);
+
+				if(timeToAddInMillis > 0){
+					if (self->ui->countdownTypeTabWidget->currentIndex() == 0) {
+						self->countdownTimerData->timeLeftInMillis += timeToAddInMillis;
+						obs_data_set_bool(response_data, "success", true);
+					} else if(self->ui->countdownTypeTabWidget->currentIndex() == 1){
+						QDateTime updatedDateTime = self->ui->dateTimeEdit->dateTime().addMSecs(timeToAddInMillis);
+						self->ui->dateTimeEdit->setDateTime(updatedDateTime);
+						obs_data_set_bool(response_data, "success", true);
+					}	
+				} else {
+					obs_log(LOG_WARNING, "No time was added to timer from websocket request.");
+					obs_data_set_bool(response_data, "success", false);
+					obs_data_set_string(response_data, "message", "No time was added to timer. Ensure time is in format \"dd:hh:mm:ss\"");
+				}
+			}
+
+		}, this);
+
 #undef WEBSOCKET_CALLBACK
+}
+
+long long CountdownDockWidget::AddTimeToTimer(const char* time_string, CountdownDockWidget *widget) {
+	UNUSED_PARAMETER(widget);
+	int days = 0, hours = 0, minutes = 0, seconds = 0;
+
+	// Count the number of colons in the string
+    int colonCount = 0;
+    for (const char* c = time_string; *c != '\0'; ++c) {
+        if (*c == ':') ++colonCount;
+    }
+
+	switch (colonCount)
+	{
+	case 0:
+		sscanf(time_string, "%d", &seconds);
+		break;
+	case 1:
+		sscanf(time_string, "%d:%d", &minutes, &seconds);
+		break;
+	case 2:
+		sscanf(time_string, "%d:%d:%d", &hours, &minutes, &seconds);
+		break;
+	case 4:
+		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes, &seconds);
+		break;
+	default:
+		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes, &seconds);
+		break;
+	}
+
+	// Convert each unit into milliseconds and sum them up
+    long long totalMilliseconds = 0;
+    totalMilliseconds += static_cast<long long>(days) * 86400000; // 24 * 60 * 60 * 1000
+    totalMilliseconds += static_cast<long long>(hours) * 3600000; // 60 * 60 * 1000
+    totalMilliseconds += static_cast<long long>(minutes) * 60000; // 60 * 1000
+    totalMilliseconds += static_cast<long long>(seconds) * 1000;  // 1000
+    return totalMilliseconds;
 }
 
 void CountdownDockWidget::UnregisterHotkeys()
@@ -553,15 +625,6 @@ CountdownDockWidget::CalculateDateTimeDifference(QDateTime timeToCountdownTo)
 
 	millisecondsDifference =
 		millisecondsDifference + 1000; // Add 1 second for countdown
-
-	obs_log(LOG_INFO, "System Time: %s",
-		systemTime.toString().toUtf8().constData());
-	obs_log(LOG_INFO, "System Time: %lld", systemTime.toMSecsSinceEpoch());
-	obs_log(LOG_INFO, "Time To Count To: %s",
-		timeToCountdownTo.toString().toUtf8().constData());
-	obs_log(LOG_INFO, "Time To Count To: %lld",
-		timeToCountdownTo.toMSecsSinceEpoch());
-	obs_log(LOG_INFO, "Time Difference: %lld", millisecondsDifference);
 
 	if (millisecondsDifference > 0) {
 		millisResult = millisecondsDifference;
@@ -889,9 +952,6 @@ void CountdownDockWidget::LoadSavedSettings(Ui::CountdownTimer *ui)
 
 		int selectedTimerTabIndex =
 			(int)obs_data_get_int(data, "selectedTimerTabIndex");
-
-		UNUSED_PARAMETER(selectedTextSource);
-		UNUSED_PARAMETER(selectedSceneSource);
 
 		// Apply saved data to plugin
 		ui->timerDays->setText(QString::number(days));

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -185,7 +185,7 @@ void CountdownDockWidget::RegisterHotkeys(CountdownWidgetStruct *context)
 		Ui::CountdownTimer &countdownUi =                              \
 			*static_cast<Ui::CountdownTimer *>(incoming_data);     \
 		if ((pred) && pressed) {                                       \
-			blog(LOG_INFO, log_action " due to hotkey");           \
+			obs_log(LOG_INFO, log_action " due to hotkey");           \
 			method();                                              \
 		}                                                              \
 	}
@@ -258,7 +258,7 @@ void CountdownDockWidget::ConfigureWebSocketConnection()
 	vendor = obs_websocket_register_vendor("ashmanix-countdown-timer");
 
 	if (!vendor) {
-		blog(LOG_ERROR, "Error registering vendor to websocket!");
+		obs_log(LOG_ERROR, "Error registering vendor to websocket!");
 		return;
 	}
 
@@ -268,7 +268,7 @@ void CountdownDockWidget::ConfigureWebSocketConnection()
 		UNUSED_PARAMETER(request_data);                             \
 		CountdownDockWidget &cdWidget =                             \
 			*static_cast<CountdownDockWidget *>(incoming_data); \
-		blog(LOG_INFO, log_action " due to websocket call");        \
+		obs_log(LOG_INFO, log_action " due to websocket call");        \
 		method();                                                   \
 		obs_data_set_bool(response_data, "success", true);          \
 	}
@@ -554,14 +554,14 @@ CountdownDockWidget::CalculateDateTimeDifference(QDateTime timeToCountdownTo)
 	millisecondsDifference =
 		millisecondsDifference + 1000; // Add 1 second for countdown
 
-	blog(LOG_INFO, "System Time: %s",
+	obs_log(LOG_INFO, "System Time: %s",
 	     systemTime.toString().toUtf8().constData());
-	blog(LOG_INFO, "System Time: %lld", systemTime.toMSecsSinceEpoch());
-	blog(LOG_INFO, "Time To Count To: %s",
+	obs_log(LOG_INFO, "System Time: %lld", systemTime.toMSecsSinceEpoch());
+	obs_log(LOG_INFO, "Time To Count To: %s",
 	     timeToCountdownTo.toString().toUtf8().constData());
-	blog(LOG_INFO, "Time To Count To: %lld",
+	obs_log(LOG_INFO, "Time To Count To: %lld",
 	     timeToCountdownTo.toMSecsSinceEpoch());
-	blog(LOG_INFO, "Time Difference: %lld", millisecondsDifference);
+	obs_log(LOG_INFO, "Time Difference: %lld", millisecondsDifference);
 
 	if (millisecondsDifference > 0) {
 		millisResult = millisecondsDifference;
@@ -1009,7 +1009,7 @@ void CountdownDockWidget::SaveSettings()
 	// Hotkeys
 	auto SaveHotkey = [](obs_data_t *sv_data, obs_hotkey_id id,
 			     const char *name) {
-		blog(LOG_INFO, "Hotkey ID: %i, Value: %s", (int)id, name);
+		obs_log(LOG_INFO, "Hotkey ID: %i, Value: %s", (int)id, name);
 		if ((int)id == -1)
 			return;
 		OBSDataArrayAutoRelease array = obs_hotkey_save(id);

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -185,7 +185,7 @@ void CountdownDockWidget::RegisterHotkeys(CountdownWidgetStruct *context)
 		Ui::CountdownTimer &countdownUi =                              \
 			*static_cast<Ui::CountdownTimer *>(incoming_data);     \
 		if ((pred) && pressed) {                                       \
-			obs_log(LOG_INFO, log_action " due to hotkey");           \
+			obs_log(LOG_INFO, log_action " due to hotkey");        \
 			method();                                              \
 		}                                                              \
 	}
@@ -268,7 +268,7 @@ void CountdownDockWidget::ConfigureWebSocketConnection()
 		UNUSED_PARAMETER(request_data);                             \
 		CountdownDockWidget &cdWidget =                             \
 			*static_cast<CountdownDockWidget *>(incoming_data); \
-		obs_log(LOG_INFO, log_action " due to websocket call");        \
+		obs_log(LOG_INFO, log_action " due to websocket call");     \
 		method();                                                   \
 		obs_data_set_bool(response_data, "success", true);          \
 	}
@@ -555,12 +555,12 @@ CountdownDockWidget::CalculateDateTimeDifference(QDateTime timeToCountdownTo)
 		millisecondsDifference + 1000; // Add 1 second for countdown
 
 	obs_log(LOG_INFO, "System Time: %s",
-	     systemTime.toString().toUtf8().constData());
+		systemTime.toString().toUtf8().constData());
 	obs_log(LOG_INFO, "System Time: %lld", systemTime.toMSecsSinceEpoch());
 	obs_log(LOG_INFO, "Time To Count To: %s",
-	     timeToCountdownTo.toString().toUtf8().constData());
+		timeToCountdownTo.toString().toUtf8().constData());
 	obs_log(LOG_INFO, "Time To Count To: %lld",
-	     timeToCountdownTo.toMSecsSinceEpoch());
+		timeToCountdownTo.toMSecsSinceEpoch());
 	obs_log(LOG_INFO, "Time Difference: %lld", millisecondsDifference);
 
 	if (millisecondsDifference > 0) {

--- a/src/countdown-widget.hpp
+++ b/src/countdown-widget.hpp
@@ -128,6 +128,7 @@ private:
 
 	static int CheckSourceType(obs_source_t *source);
 	static void LoadSavedSettings(Ui::CountdownTimer *ui);
+	static long long AddTimeToTimer(const char* time_string, CountdownDockWidget *widget);
 
 private slots:
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -43,7 +43,7 @@ bool obs_module_load(void)
 				    countdownWidget);
 	obs_frontend_pop_ui_translation();
 
-	blog(LOG_INFO, "plugin loaded successfully (version %s)",
+	obs_log(LOG_INFO, "plugin loaded successfully (version %s)",
 	     PLUGIN_VERSION);
 	return true;
 }
@@ -55,7 +55,7 @@ void obs_module_post_load(void)
 
 void obs_module_unload()
 {
-	blog(LOG_INFO, "plugin unloaded");
+	obs_log(LOG_INFO, "plugin unloaded");
 }
 
 const char *obs_module_name(void)

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -44,7 +44,7 @@ bool obs_module_load(void)
 	obs_frontend_pop_ui_translation();
 
 	obs_log(LOG_INFO, "plugin loaded successfully (version %s)",
-	     PLUGIN_VERSION);
+		PLUGIN_VERSION);
 	return true;
 }
 


### PR DESCRIPTION
This feature allows the user to add more time to the countdown timer via a command sent to the OBS websocket. I've also changed all references of `blog` to the new `obs_log` function used by the new plugin template code.