### PR TITLE
Fix - Loaded date is before current date

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -1028,9 +1028,10 @@ void CountdownDockWidget::LoadSavedSettings(Ui::CountdownTimer *ui)
 		// If saved date is before current date then set date to today (while keeping same time)
 		QDateTime currentTime = QDateTime::currentDateTime();
 
-		if(currentTime > savedTime) {
+		if (currentTime > savedTime) {
 			savedTime = savedTime.addDays(1);
-			if(currentTime > savedTime) savedTime = savedTime.addDays(1);
+			if (currentTime > savedTime)
+				savedTime = savedTime.addDays(1);
 		}
 
 		ui->dateTimeEdit->setDateTime(savedTime);

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -1025,6 +1025,14 @@ void CountdownDockWidget::LoadSavedSettings(Ui::CountdownTimer *ui)
 			(Qt::CheckState)switchSceneCheckBoxStatus);
 
 		QDateTime savedTime = QDateTime::fromString(countdownToTime);
+		// If saved date is before current date then set date to today (while keeping same time)
+		QDateTime currentTime = QDateTime::currentDateTime();
+
+		if(currentTime > savedTime) {
+			savedTime = savedTime.addDays(1);
+			if(currentTime > savedTime) savedTime = savedTime.addDays(1);
+		}
+
 		ui->dateTimeEdit->setDateTime(savedTime);
 
 		int textSelectIndex = ui->textSourceDropdownList->findText(


### PR DESCRIPTION
Plugin now checks whether saved datetime is before current datetime and will either save 1 or 2 days to ensure the datetime is after the current time when plugin is opened. The time will always remain the same.