### PR TITLE
Toggle UI for single and multiple timers

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -227,9 +227,9 @@ void CountdownDockWidget::AddTimer(obs_data_t *savedData)
 	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
 
 	if (GetNumberOfTimers() == 1 && firstTimerWidget) {
-		firstTimerWidget->SetIsDeleteButtonDisabled(true);
+		firstTimerWidget->SetHideMultiTimerUIButtons(true);
 	} else {
-		firstTimerWidget->SetIsDeleteButtonDisabled(false);
+		firstTimerWidget->SetHideMultiTimerUIButtons(false);
 	}
 
 	UpdateTimerListMoveButtonState();
@@ -547,7 +547,7 @@ void CountdownDockWidget::RemoveTimerButtonClicked(QString id)
 	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
 	int noOfTImers = GetNumberOfTimers();
 	if (noOfTImers == 1 && firstTimerWidget) {
-		firstTimerWidget->SetIsDeleteButtonDisabled(true);
+		firstTimerWidget->SetHideMultiTimerUIButtons(true);
 	}
 	UpdateTimerListMoveButtonState();
 }

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -224,14 +224,7 @@ void CountdownDockWidget::AddTimer(obs_data_t *savedData)
 
 	timerListLayout->addWidget(newTimer);
 
-	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
-
-	if (GetNumberOfTimers() == 1 && firstTimerWidget) {
-		firstTimerWidget->SetHideMultiTimerUIButtons(true);
-	} else {
-		firstTimerWidget->SetHideMultiTimerUIButtons(false);
-	}
-
+	ToggleUIForMultipleTimers();
 	UpdateTimerListMoveButtonState();
 }
 
@@ -523,6 +516,24 @@ void CountdownDockWidget::HandleWebsocketButtonPressRequest(
 	}
 }
 
+void CountdownDockWidget::ToggleUIForMultipleTimers()
+{
+	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
+	int noOfTImers = GetNumberOfTimers();
+
+	if (firstTimerWidget) {
+		if (noOfTImers == 1) {
+			firstTimerWidget->SetHideMultiTimerUIButtons(true);
+			ui->playAllButton->hide();
+			ui->stopAllButton->hide();
+		} else {
+			firstTimerWidget->SetHideMultiTimerUIButtons(false);
+			ui->playAllButton->show();
+			ui->stopAllButton->show();
+		}
+	}
+}
+
 // --------------------------------- Private Slots ----------------------------------
 
 void CountdownDockWidget::AddTimerButtonClicked()
@@ -542,13 +553,7 @@ void CountdownDockWidget::RemoveTimerButtonClicked(QString id)
 					  .c_str());
 	}
 
-	// There should always be 1 timer in list therefore we disable
-	// the delete button if only 1 timer is left.
-	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
-	int noOfTImers = GetNumberOfTimers();
-	if (noOfTImers == 1 && firstTimerWidget) {
-		firstTimerWidget->SetHideMultiTimerUIButtons(true);
-	}
+	ToggleUIForMultipleTimers();
 	UpdateTimerListMoveButtonState();
 }
 

--- a/src/countdown-widget.hpp
+++ b/src/countdown-widget.hpp
@@ -98,6 +98,7 @@ private:
 	void UnregisterAllHotkeys();
 	void AddTimer(obs_data_t *savedData = nullptr);
 	void UpdateTimerListMoveButtonState();
+	void ToggleUIForMultipleTimers();
 	static void
 	StartTimersOnStreamStart(CountdownDockWidget *countdownDockWidget);
 	static void

--- a/src/ui/AshmanixTimer.ui
+++ b/src/ui/AshmanixTimer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>309</width>
-    <height>280</height>
+    <width>302</width>
+    <height>199</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,7 +57,7 @@
        <number>5</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <layout class="QHBoxLayout" name="timerTitleHLayout">
         <property name="topMargin">
          <number>0</number>
         </property>
@@ -108,6 +108,12 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
           </property>
           <property name="font">
            <font>

--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -185,9 +185,22 @@ TimerWidgetStruct *AshmanixTimer::GetTimerData()
 	return &countdownTimerData;
 }
 
-void AshmanixTimer::SetIsDeleteButtonDisabled(bool isDisabled)
+void AshmanixTimer::SetHideMultiTimerUIButtons(bool shouldHide)
 {
-	ui->deleteToolButton->setDisabled(isDisabled);
+	if (shouldHide) {
+
+		ui->deleteToolButton->setDisabled(true);
+		ui->deleteToolButton->hide();
+		ui->timerTitleHLayout->insertItem(0, deleteButtonSpacer);
+		ui->moveUpToolButton->hide();
+		ui->moveDownToolButton->hide();
+	} else {
+		ui->timerTitleHLayout->removeItem(deleteButtonSpacer);
+		ui->deleteToolButton->setDisabled(false);
+		ui->deleteToolButton->show();
+		ui->moveUpToolButton->show();
+		ui->moveDownToolButton->show();
+	}
 }
 
 void AshmanixTimer::SetIsUpButtonDisabled(bool isDisabled)
@@ -400,6 +413,11 @@ void AshmanixTimer::SetupTimerWidgetUI()
 	ui->toTimeStopButton->setEnabled(false);
 	ui->toTimeStopButton->setToolTip(
 		obs_module_text("ToTimeStopButtonTip"));
+
+	deleteButtonSpacer =
+		new QSpacerItem(ui->deleteToolButton->sizeHint().width(),
+				ui->deleteToolButton->sizeHint().height(),
+				QSizePolicy::Fixed, QSizePolicy::Fixed);
 
 	UpdateTimeDisplayTooltip();
 

--- a/src/widgets/ashmanix-timer.hpp
+++ b/src/widgets/ashmanix-timer.hpp
@@ -38,7 +38,7 @@ public:
 
 	QString GetTimerID();
 	TimerWidgetStruct *GetTimerData();
-	void SetIsDeleteButtonDisabled(bool isDisabled);
+	void SetHideMultiTimerUIButtons(bool shouldHide);
 	void SetIsUpButtonDisabled(bool isDisabled);
 	void SetIsDownButtonDisabled(bool isDisabled);
 	void SetTimerData();
@@ -60,6 +60,7 @@ private:
 	static inline const char *ZEROSTRING = "00:00:00:00";
 	obs_websocket_vendor vendor = nullptr;
 	long long lastDisplayedSeconds = -1;
+	QSpacerItem *deleteButtonSpacer;
 
 	static inline const char *TIMERSTARTHOTKEYNAME =
 		"Ashmanix_Countdown_Timer_Start";


### PR DESCRIPTION
This PR introduces the following changes:

When one timer is shown the following buttons will be hidden:
- Delete button for the single timer
- Up/Down toggle buttons for single timer
- Play all and Stop all buttons for the main countdown widget

These buttons will be shown again as soon as there are more than one timer in the list.