### PR TITLE
Fix - Deleting First Timer When Two Left Doesn't Toggle UI

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -518,15 +518,24 @@ void CountdownDockWidget::HandleWebsocketButtonPressRequest(
 
 void CountdownDockWidget::ToggleUIForMultipleTimers()
 {
-	AshmanixTimer *firstTimerWidget = GetFirstTimerWidget();
+
+	AshmanixTimer *firstTimerWidget = nullptr;
 	int noOfTImers = GetNumberOfTimers();
 
-	if (firstTimerWidget) {
-		if (noOfTImers == 1) {
+	if (noOfTImers == 1) {
+		// If only one timer left we use timer map to get last timer
+		// as deletion of timers is delayed and we might get an old
+		// reference when getting timer in layout
+		firstTimerWidget = static_cast<AshmanixTimer *>(
+			timerWidgetMap.begin().value());
+		if (firstTimerWidget) {
 			firstTimerWidget->SetHideMultiTimerUIButtons(true);
 			ui->playAllButton->hide();
 			ui->stopAllButton->hide();
-		} else {
+		}
+	} else {
+		firstTimerWidget = GetFirstTimerWidget();
+		if (firstTimerWidget) {
 			firstTimerWidget->SetHideMultiTimerUIButtons(false);
 			ui->playAllButton->show();
 			ui->stopAllButton->show();


### PR DESCRIPTION
This change adds a fix for a bug where if you have two timers in the list and you delete the first timer then the remaining timers UI doesn't toggle when it is the last one left. I'm now using the timer QMap to get the reference to the last timer in the list as this updates straight away where the widget layout takes time to delete the timer widget,