### PR TITLE
OBS Signal Disconnect

### DIFF
--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -120,7 +120,7 @@ void CountdownDockWidget::SetupCountdownWidgetUI()
 			    "#mainTimerWidget {"
 			    "   border-left: none;"
 			    "   border-right: none;"
-			    "});");
+			    "}");
 }
 
 void CountdownDockWidget::ConnectUISignalHandlers()

--- a/src/widgets/settings-dialog.cpp
+++ b/src/widgets/settings-dialog.cpp
@@ -18,6 +18,14 @@ SettingsDialog::SettingsDialog(QWidget *parent, TimerWidgetStruct *tData)
 
 SettingsDialog::~SettingsDialog()
 {
+	// Disconnect OBS signals before the dialog is destroyed
+	signal_handler_disconnect(obs_get_signal_handler(), "source_create",
+				  OBSSourceCreated, ui);
+	signal_handler_disconnect(obs_get_signal_handler(), "source_destroy",
+				  OBSSourceDeleted, ui);
+	signal_handler_disconnect(obs_get_signal_handler(), "source_rename",
+				  OBSSourceRenamed, ui);
+
 	this->deleteLater();
 }
 


### PR DESCRIPTION
This change carries out the following:
- Disconnects OBS signals on timer deletion
- Fixed syntax error for stylsheet