### PR TITLE
Fix/websocket set and add time bug

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakStringLiterals: false  # apparently unpredictable
-ColumnLimit: 80
+ColumnLimit: 120
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -1,9 +1,7 @@
 #include "countdown-widget.hpp"
 #include "widgets/ashmanix-timer.hpp"
 
-CountdownDockWidget::CountdownDockWidget(QWidget *parent)
-	: OBSDock(parent),
-	  ui(new Ui::CountdownTimer)
+CountdownDockWidget::CountdownDockWidget(QWidget *parent) : OBSDock(parent), ui(new Ui::CountdownTimer)
 {
 	// Register custom type for signals and slots
 	qRegisterMetaType<obs_data_t *>("obs_data_t*");
@@ -35,8 +33,7 @@ AshmanixTimer *CountdownDockWidget::GetFirstTimerWidget()
 	QLayoutItem *layout = ui->timerMainLayout->itemAt(0);
 	AshmanixTimer *firstTimerWidget = nullptr;
 	if (layout) {
-		firstTimerWidget =
-			static_cast<AshmanixTimer *>(layout->widget());
+		firstTimerWidget = static_cast<AshmanixTimer *>(layout->widget());
 	}
 	return firstTimerWidget;
 }
@@ -58,8 +55,7 @@ Result CountdownDockWidget::UpdateTimerList(QString oldId, QString newId)
 	Result result = {false, ""};
 
 	if (!foundTimer) {
-		obs_log(LOG_ERROR, "Could not find timer ID %s in saved list!",
-			oldId.toStdString().c_str());
+		obs_log(LOG_ERROR, "Could not find timer ID %s in saved list!", oldId.toStdString().c_str());
 		result = {false, obs_module_text("DialogTimerIdUpdateError")};
 	} else {
 		foundTimer->SetTimerID(newId);
@@ -78,47 +74,32 @@ void CountdownDockWidget::ConfigureWebSocketConnection()
 		return;
 	}
 
-	obs_websocket_vendor_register_request(
-		vendor, "period_play", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, PERIOD_PLAY, NULL, TIMERIDKEY});
-	obs_websocket_vendor_register_request(
-		vendor, "period_pause", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, PERIOD_PAUSE, NULL,
-					  TIMERIDKEY});
-	obs_websocket_vendor_register_request(
-		vendor, "period_set", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, PERIOD_SET, NULL, TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "period_play", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, PERIOD_PLAY, NULL, TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "period_pause", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, PERIOD_PAUSE, NULL, TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "period_set", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, PERIOD_SET, NULL, TIMERIDKEY});
 
-	obs_websocket_vendor_register_request(
-		vendor, "to_time_play", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, TO_TIME_PLAY, NULL,
-					  TIMERIDKEY});
-	obs_websocket_vendor_register_request(
-		vendor, "to_time_stop", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, TO_TIME_STOP, NULL,
-					  TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "to_time_play", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, TO_TIME_PLAY, NULL, TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "to_time_stop", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, TO_TIME_STOP, NULL, TIMERIDKEY});
 
-	obs_websocket_vendor_register_request(
-		vendor, "play_all", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, PLAY_ALL, NULL, NULL});
+	obs_websocket_vendor_register_request(vendor, "play_all", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, PLAY_ALL, NULL, NULL});
 
-	obs_websocket_vendor_register_request(
-		vendor, "stop_all", HandleWebsocketButtonPressRequest,
-		new WebsocketCallbackData{this, STOP_ALL, NULL, NULL});
+	obs_websocket_vendor_register_request(vendor, "stop_all", HandleWebsocketButtonPressRequest,
+					      new WebsocketCallbackData{this, STOP_ALL, NULL, NULL});
 
-	obs_websocket_vendor_register_request(
-		vendor, "get_timer_state", GetTimerStateViaWebsocket,
-		new WebsocketCallbackData{this, GET_TIME, NULL, TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "get_timer_state", GetTimerStateViaWebsocket,
+					      new WebsocketCallbackData{this, GET_TIME, NULL, TIMERIDKEY});
 
-	obs_websocket_vendor_register_request(
-		vendor, "add_time", ChangeTimerTimeViaWebsocket,
-		new WebsocketCallbackData{this, ADD_TIME, "time_to_add",
-					  TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "add_time", ChangeTimerTimeViaWebsocket,
+					      new WebsocketCallbackData{this, ADD_TIME, "time_to_add", TIMERIDKEY});
 
-	obs_websocket_vendor_register_request(
-		vendor, "set_time", ChangeTimerTimeViaWebsocket,
-		new WebsocketCallbackData{this, SET_TIME, "time_to_set",
-					  TIMERIDKEY});
+	obs_websocket_vendor_register_request(vendor, "set_time", ChangeTimerTimeViaWebsocket,
+					      new WebsocketCallbackData{this, SET_TIME, "time_to_set", TIMERIDKEY});
 }
 
 void CountdownDockWidget::SetupCountdownWidgetUI()
@@ -131,14 +112,12 @@ void CountdownDockWidget::SetupCountdownWidgetUI()
 	ui->playAllButton->setProperty("themeID", "playIcon");
 	ui->playAllButton->setProperty("class", "icon-media-play");
 	ui->playAllButton->setEnabled(true);
-	ui->playAllButton->setToolTip(
-		obs_module_text("StartAllTimersButtonTip"));
+	ui->playAllButton->setToolTip(obs_module_text("StartAllTimersButtonTip"));
 
 	ui->stopAllButton->setProperty("themeID", "stopIcon");
 	ui->stopAllButton->setProperty("class", "icon-media-stop");
 	ui->stopAllButton->setEnabled(true);
-	ui->stopAllButton->setToolTip(
-		obs_module_text("StopAllTimersButtonTip"));
+	ui->stopAllButton->setToolTip(obs_module_text("StopAllTimersButtonTip"));
 
 	this->setStyleSheet("#dialogMainWidget QDialogButtonBox QPushButton {"
 			    "   width: auto;"
@@ -154,26 +133,21 @@ void CountdownDockWidget::SetupCountdownWidgetUI()
 
 void CountdownDockWidget::ConnectUISignalHandlers()
 {
-	QObject::connect(ui->addTimerButton, &QPushButton::clicked, this,
-			 &CountdownDockWidget::AddTimerButtonClicked);
+	QObject::connect(ui->addTimerButton, &QPushButton::clicked, this, &CountdownDockWidget::AddTimerButtonClicked);
 
-	QObject::connect(ui->playAllButton, &QPushButton::clicked, this,
-			 &CountdownDockWidget::StartAllTimers);
+	QObject::connect(ui->playAllButton, &QPushButton::clicked, this, &CountdownDockWidget::StartAllTimers);
 
-	QObject::connect(ui->stopAllButton, &QPushButton::clicked, this,
-			 &CountdownDockWidget::StopAllTimers);
+	QObject::connect(ui->stopAllButton, &QPushButton::clicked, this, &CountdownDockWidget::StopAllTimers);
 }
 
 void CountdownDockWidget::ConnectTimerSignalHandlers(AshmanixTimer *timerWidget)
 {
-	connect(timerWidget, &AshmanixTimer::RequestDelete, this,
-		&CountdownDockWidget::RemoveTimerButtonClicked);
+	connect(timerWidget, &AshmanixTimer::RequestDelete, this, &CountdownDockWidget::RemoveTimerButtonClicked);
 
 	connect(timerWidget, &AshmanixTimer::RequestSendWebsocketEvent, this,
 		&CountdownDockWidget::HandleWebsocketSendEvent);
 
-	connect(timerWidget, &AshmanixTimer::MoveTimer, this,
-		&CountdownDockWidget::MoveTimerInList);
+	connect(timerWidget, &AshmanixTimer::MoveTimer, this, &CountdownDockWidget::MoveTimerInList);
 }
 
 void CountdownDockWidget::SaveSettings()
@@ -186,19 +160,13 @@ void CountdownDockWidget::SaveSettings()
 	for (int i = 0; i < mainLayout->count(); ++i) {
 		QLayoutItem *item = mainLayout->itemAt(i);
 		if (item) {
-			AshmanixTimer *timerWidget =
-				qobject_cast<AshmanixTimer *>(item->widget());
+			AshmanixTimer *timerWidget = qobject_cast<AshmanixTimer *>(item->widget());
 			if (timerWidget) {
-				TimerWidgetStruct *timerData =
-					timerWidget->GetTimerData();
+				TimerWidgetStruct *timerData = timerWidget->GetTimerData();
 				if (timerData) {
-					obs_data_t *dataObject =
-						obs_data_create();
-					timerWidget
-						->SaveTimerWidgetDataToOBSSaveData(
-							dataObject);
-					obs_data_array_push_back(obsDataArray,
-								 dataObject);
+					obs_data_t *dataObject = obs_data_create();
+					timerWidget->SaveTimerWidgetDataToOBSSaveData(dataObject);
+					obs_data_array_push_back(obsDataArray, dataObject);
 
 					obs_data_release(dataObject);
 				}
@@ -231,22 +199,16 @@ void CountdownDockWidget::SaveSettings()
 void CountdownDockWidget::RegisterAllHotkeys(obs_data_t *savedData)
 {
 	LoadHotkey(
-		addTimerHotkeyId, addTimerHotkeyName,
-		obs_module_text("AddTimerHotkeyDescription"),
-		[this]() { ui->addTimerButton->click(); },
-		"Add Timer Hotkey Pressed", savedData);
+		addTimerHotkeyId, addTimerHotkeyName, obs_module_text("AddTimerHotkeyDescription"),
+		[this]() { ui->addTimerButton->click(); }, "Add Timer Hotkey Pressed", savedData);
 
 	LoadHotkey(
-		startAllTimersHotkeyId, startAllTimersHotkeyName,
-		obs_module_text("StartAllTimersHotkeyDescription"),
-		[this]() { ui->playAllButton->click(); },
-		"Start All Timers Hotkey Pressed", savedData);
+		startAllTimersHotkeyId, startAllTimersHotkeyName, obs_module_text("StartAllTimersHotkeyDescription"),
+		[this]() { ui->playAllButton->click(); }, "Start All Timers Hotkey Pressed", savedData);
 
 	LoadHotkey(
-		stopAllTimersHotkeyId, stopAllTimersHotkeyName,
-		obs_module_text("StopAllTimersHotkeyDescription"),
-		[this]() { ui->stopAllButton->click(); },
-		"Stop All Timers Hotkey Pressed", savedData);
+		stopAllTimersHotkeyId, stopAllTimersHotkeyName, obs_module_text("StopAllTimersHotkeyDescription"),
+		[this]() { ui->stopAllButton->click(); }, "Stop All Timers Hotkey Pressed", savedData);
 }
 
 void CountdownDockWidget::UnregisterAllHotkeys()
@@ -257,8 +219,7 @@ void CountdownDockWidget::UnregisterAllHotkeys()
 
 void CountdownDockWidget::AddTimer(obs_data_t *savedData)
 {
-	AshmanixTimer *newTimer =
-		new AshmanixTimer(this, vendor, savedData, this);
+	AshmanixTimer *newTimer = new AshmanixTimer(this, vendor, savedData, this);
 
 	timerWidgetMap.insert(newTimer->GetTimerID(), newTimer);
 	ConnectTimerSignalHandlers(newTimer);
@@ -273,8 +234,7 @@ void CountdownDockWidget::UpdateTimerListMoveButtonState()
 {
 	int timerWidgetCount = ui->timerMainLayout->count();
 	for (int i = 0; i < timerWidgetCount; i++) {
-		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(
-			ui->timerMainLayout->itemAt(i)->widget());
+		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(ui->timerMainLayout->itemAt(i)->widget());
 		if (timerWidget) {
 			if (i == 0) {
 				timerWidget->SetIsUpButtonDisabled(true);
@@ -289,43 +249,34 @@ void CountdownDockWidget::UpdateTimerListMoveButtonState()
 		}
 	}
 }
-void CountdownDockWidget::StartTimersOnStreamStart(
-	CountdownDockWidget *countdownDockWidget)
+void CountdownDockWidget::StartTimersOnStreamStart(CountdownDockWidget *countdownDockWidget)
 {
-	int timerWidgetCount =
-		countdownDockWidget->ui->timerMainLayout->count();
+	int timerWidgetCount = countdownDockWidget->ui->timerMainLayout->count();
 	for (int i = 0; i < timerWidgetCount; i++) {
-		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(
-			countdownDockWidget->ui->timerMainLayout->itemAt(i)
-				->widget());
-		if (timerWidget &&
-		    timerWidget->GetTimerData()->startOnStreamStart) {
+		AshmanixTimer *timerWidget =
+			static_cast<AshmanixTimer *>(countdownDockWidget->ui->timerMainLayout->itemAt(i)->widget());
+		if (timerWidget && timerWidget->GetTimerData()->startOnStreamStart) {
 			timerWidget->StartTimer();
 		}
 	}
 }
 
-void CountdownDockWidget::UpdateWidgetStyles(
-	CountdownDockWidget *countdownDockWidget)
+void CountdownDockWidget::UpdateWidgetStyles(CountdownDockWidget *countdownDockWidget)
 {
-	int timerWidgetCount =
-		countdownDockWidget->ui->timerMainLayout->count();
+	int timerWidgetCount = countdownDockWidget->ui->timerMainLayout->count();
 	for (int i = 0; i < timerWidgetCount; i++) {
-		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(
-			countdownDockWidget->ui->timerMainLayout->itemAt(i)
-				->widget());
+		AshmanixTimer *timerWidget =
+			static_cast<AshmanixTimer *>(countdownDockWidget->ui->timerMainLayout->itemAt(i)->widget());
 		if (timerWidget) {
 			timerWidget->UpdateStyles();
 		}
 	}
 }
 
-void CountdownDockWidget::OBSFrontendEventHandler(enum obs_frontend_event event,
-						  void *private_data)
+void CountdownDockWidget::OBSFrontendEventHandler(enum obs_frontend_event event, void *private_data)
 {
 
-	CountdownDockWidget *countdownDockWidget =
-		(CountdownDockWidget *)private_data;
+	CountdownDockWidget *countdownDockWidget = (CountdownDockWidget *)private_data;
 
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
@@ -335,8 +286,7 @@ void CountdownDockWidget::OBSFrontendEventHandler(enum obs_frontend_event event,
 		CountdownDockWidget::UpdateWidgetStyles(countdownDockWidget);
 		break;
 	case OBS_FRONTEND_EVENT_STREAMING_STARTED:
-		CountdownDockWidget::StartTimersOnStreamStart(
-			countdownDockWidget);
+		CountdownDockWidget::StartTimersOnStreamStart(countdownDockWidget);
 		break;
 	default:
 		break;
@@ -353,13 +303,11 @@ void CountdownDockWidget::LoadSavedSettings(CountdownDockWidget *dockWidget)
 	}
 	if (data) {
 		// Get Save Data
-		obs_data_array_t *timersArray =
-			obs_data_get_array(data, "timer_widgets");
+		obs_data_array_t *timersArray = obs_data_get_array(data, "timer_widgets");
 		if (timersArray) {
 			size_t count = obs_data_array_count(timersArray);
 			for (size_t i = 0; i < count; ++i) {
-				obs_data_t *timerDataObj =
-					obs_data_array_item(timersArray, i);
+				obs_data_t *timerDataObj = obs_data_array_item(timersArray, i);
 				dockWidget->AddTimer(timerDataObj);
 			}
 		}
@@ -376,26 +324,22 @@ void CountdownDockWidget::LoadSavedSettings(CountdownDockWidget *dockWidget)
 	}
 }
 
-AshmanixTimer *CountdownDockWidget::AttemptToGetTimerWidgetById(
-	CountdownDockWidget *countdownWidget, const char *websocketTimerID)
+AshmanixTimer *CountdownDockWidget::AttemptToGetTimerWidgetById(CountdownDockWidget *countdownWidget,
+								const char *websocketTimerID)
 {
 	AshmanixTimer *timer = nullptr;
 	if (websocketTimerID != nullptr && strlen(websocketTimerID) > 0) {
-		timer = countdownWidget->timerWidgetMap.value(websocketTimerID,
-							      nullptr);
+		timer = countdownWidget->timerWidgetMap.value(websocketTimerID, nullptr);
 	} else if (countdownWidget->timerListLayout->count()) {
-		QLayoutItem *layoutItem =
-			countdownWidget->timerListLayout->itemAt(0);
+		QLayoutItem *layoutItem = countdownWidget->timerListLayout->itemAt(0);
 		if (layoutItem) {
-			timer = qobject_cast<AshmanixTimer *>(
-				layoutItem->widget());
+			timer = qobject_cast<AshmanixTimer *>(layoutItem->widget());
 		}
 	}
 	return timer;
 }
 
-void CountdownDockWidget::ChangeTimerTimeViaWebsocket(obs_data_t *request_data,
-						      obs_data_t *response_data,
+void CountdownDockWidget::ChangeTimerTimeViaWebsocket(obs_data_t *request_data, obs_data_t *response_data,
 						      void *priv_data)
 {
 	auto *callback_data = static_cast<WebsocketCallbackData *>(priv_data);
@@ -403,95 +347,74 @@ void CountdownDockWidget::ChangeTimerTimeViaWebsocket(obs_data_t *request_data,
 	const char *requestDataTimeKey = callback_data->requestDataKey;
 	const char *requestTimerIdKey = callback_data->requestTimerIdKey;
 
-	const char *websocketDataTime =
-		obs_data_get_string(request_data, requestDataTimeKey);
+	const char *websocketDataTime = obs_data_get_string(request_data, requestDataTimeKey);
 
 	if (websocketDataTime == nullptr || strlen(websocketDataTime) == 0) {
 		obs_data_set_bool(response_data, "success", false);
-		QString error_message =
-			QString("%1 field is missing from request!")
-				.arg(requestDataTimeKey);
-		obs_data_set_string(response_data, "message",
-				    error_message.toStdString().c_str());
+		QString error_message = QString("%1 field is missing from request!").arg(requestDataTimeKey);
+		obs_data_set_string(response_data, "message", error_message.toStdString().c_str());
 	} else {
 		CountdownDockWidget *countdownWidget = callback_data->instance;
-		const char *websocketTimerID =
-			obs_data_get_string(request_data, requestTimerIdKey);
+		const char *websocketTimerID = obs_data_get_string(request_data, requestTimerIdKey);
 
-		AshmanixTimer *timer = AttemptToGetTimerWidgetById(
-			countdownWidget, websocketTimerID);
+		AshmanixTimer *timer = AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
 
 		if (timer != nullptr) {
-			long long timeInMillis =
-				ConvertStringPeriodToMillis(websocketDataTime);
+			long long timeInMillis = ConvertStringPeriodToMillis(websocketDataTime);
 
-			if (timeInMillis > 0) {
-				bool result = timer->AlterTime(requestType,
-							       timeInMillis);
-				const char *type_string =
-					requestType == ADD_TIME ? "added"
-								: "set";
-				obs_log(LOG_INFO,
-					"Time %s due to websocket call: %s",
-					type_string, websocketDataTime);
-				obs_data_set_bool(response_data, "success",
-						  result);
-			} else {
-				obs_log(LOG_WARNING,
-					"Timer time NOT changed from websocket request.");
-				obs_data_set_bool(response_data, "success",
-						  false);
-				obs_data_set_string(
-					response_data, "message",
-					"Timer time wasn't changed. Ensure time is in format \"dd:hh:mm:ss\"");
-			}
+			obs_log(LOG_INFO, "Time in millis: %ld", timeInMillis);
+
+			// if (timeInMillis > 0) {
+			bool result = timer->AlterTime(requestType, websocketDataTime);
+			const char *type_string = requestType == ADD_TIME ? "added" : "set";
+			obs_log(LOG_INFO, "Time %s due to websocket call: %s", type_string, websocketDataTime);
+			obs_data_set_bool(response_data, "success", result);
+			// } else {
+			// 	obs_log(LOG_WARNING,
+			// 		"Timer time NOT changed from websocket request.");
+			// 	obs_data_set_bool(response_data, "success",
+			// 			  false);
+			// 	obs_data_set_string(
+			// 		response_data, "message",
+			// 		"Timer time wasn't changed. Ensure time is in format \"dd:hh:mm:ss\"");
+			// }
 		} else {
-			obs_log(LOG_WARNING,
-				"Countdown widget not found for websocket request!");
+			obs_log(LOG_WARNING, "Countdown widget not found for websocket request!");
 			obs_data_set_bool(response_data, "success", false);
-			obs_data_set_string(response_data, "message",
-					    "Error trying to update time!");
+			obs_data_set_string(response_data, "message", "Error trying to update time!");
 		}
 	}
 }
 
-void CountdownDockWidget::GetTimerStateViaWebsocket(obs_data_t *request_data,
-						    obs_data_t *response_data,
+void CountdownDockWidget::GetTimerStateViaWebsocket(obs_data_t *request_data, obs_data_t *response_data,
 						    void *priv_data)
 {
 	auto *callback_data = static_cast<WebsocketCallbackData *>(priv_data);
 	const char *requestTimerIdKey = callback_data->requestTimerIdKey;
 
 	CountdownDockWidget *countdownWidget = callback_data->instance;
-	const char *websocketTimerID =
-		obs_data_get_string(request_data, requestTimerIdKey);
+	const char *websocketTimerID = obs_data_get_string(request_data, requestTimerIdKey);
 
-	AshmanixTimer *timer =
-		AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
+	AshmanixTimer *timer = AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
 
 	if (timer != nullptr) {
 		TimerWidgetStruct *timerData = timer->GetTimerData();
-		obs_data_set_bool(response_data, "is_running",
-				  timerData->isPlaying);
-		obs_data_set_int(response_data, "time_left_ms",
-				 timerData->timeLeftInMillis);
+		obs_data_set_bool(response_data, "is_running", timerData->isPlaying);
+		obs_data_set_int(response_data, "time_left_ms", timerData->timeLeftInMillis);
 
-		obs_data_set_string(response_data, "timer_id",
-				    timerData->timerId.toStdString().c_str());
+		obs_data_set_string(response_data, "timer_id", timerData->timerId.toStdString().c_str());
 
 		obs_data_set_bool(response_data, "success", true);
 
 	} else {
-		obs_log(LOG_WARNING,
-			"Countdown widget not found for websocket request!");
+		obs_log(LOG_WARNING, "Countdown widget not found for websocket request!");
 		obs_data_set_bool(response_data, "success", false);
-		obs_data_set_string(response_data, "message",
-				    "Error trying to get timer data!");
+		obs_data_set_string(response_data, "message", "Error trying to get timer data!");
 	}
 }
 
-void CountdownDockWidget::HandleWebsocketButtonPressRequest(
-	obs_data_t *request_data, obs_data_t *response_data, void *priv_data)
+void CountdownDockWidget::HandleWebsocketButtonPressRequest(obs_data_t *request_data, obs_data_t *response_data,
+							    void *priv_data)
 {
 	auto *callback_data = static_cast<WebsocketCallbackData *>(priv_data);
 	WebsocketRequestType requestType = callback_data->requestType;
@@ -516,17 +439,13 @@ void CountdownDockWidget::HandleWebsocketButtonPressRequest(
 	}
 
 	const char *requestTimerIdKey = callback_data->requestTimerIdKey;
-	const char *websocketTimerID =
-		obs_data_get_string(request_data, requestTimerIdKey);
-	AshmanixTimer *timer =
-		AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
+	const char *websocketTimerID = obs_data_get_string(request_data, requestTimerIdKey);
+	AshmanixTimer *timer = AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
 
 	if (!timer) {
-		obs_log(LOG_WARNING,
-			"Countdown widget not found for websocket timer state change request!");
+		obs_log(LOG_WARNING, "Countdown widget not found for websocket timer state change request!");
 		obs_data_set_bool(response_data, "success", false);
-		obs_data_set_string(response_data, "message",
-				    "Error trying to change timer state!");
+		obs_data_set_string(response_data, "message", "Error trying to change timer state!");
 		return;
 	}
 
@@ -567,8 +486,7 @@ void CountdownDockWidget::ToggleUIForMultipleTimers()
 		// If only one timer left we use timer map to get last timer
 		// as deletion of timers is delayed and we might get an old
 		// reference when getting timer in layout
-		firstTimerWidget = static_cast<AshmanixTimer *>(
-			timerWidgetMap.begin().value());
+		firstTimerWidget = static_cast<AshmanixTimer *>(timerWidgetMap.begin().value());
 		if (firstTimerWidget) {
 			firstTimerWidget->SetHideMultiTimerUIButtons(true);
 			ui->playAllButton->hide();
@@ -598,17 +516,14 @@ void CountdownDockWidget::RemoveTimerButtonClicked(QString id)
 	if (itemToBeRemoved) {
 		itemToBeRemoved->deleteLater();
 		timerWidgetMap.remove(id);
-		obs_log(LOG_INFO, (QString("Timer %1 deleted").arg(id))
-					  .toStdString()
-					  .c_str());
+		obs_log(LOG_INFO, (QString("Timer %1 deleted").arg(id)).toStdString().c_str());
 	}
 
 	ToggleUIForMultipleTimers();
 	UpdateTimerListMoveButtonState();
 }
 
-void CountdownDockWidget::HandleWebsocketSendEvent(const char *eventName,
-						   obs_data_t *eventData)
+void CountdownDockWidget::HandleWebsocketSendEvent(const char *eventName, obs_data_t *eventData)
 {
 	if (!vendor)
 		return;
@@ -623,13 +538,10 @@ void CountdownDockWidget::MoveTimerInList(QString direction, QString id)
 		//Gets the index of the widget within the layout
 		const int index = ui->timerMainLayout->indexOf(timerWidget);
 		if (!(direction == "up" && index == 0) &&
-		    !(direction == "down" &&
-		      index == (ui->timerMainLayout->count() - 1))) {
-			const int newIndex = direction == "up" ? index - 1
-							       : index + 1;
+		    !(direction == "down" && index == (ui->timerMainLayout->count() - 1))) {
+			const int newIndex = direction == "up" ? index - 1 : index + 1;
 			ui->timerMainLayout->removeWidget(timerWidget);
-			ui->timerMainLayout->insertWidget(newIndex,
-							  timerWidget);
+			ui->timerMainLayout->insertWidget(newIndex, timerWidget);
 			UpdateTimerListMoveButtonState();
 		}
 	}
@@ -639,8 +551,7 @@ void CountdownDockWidget::StartAllTimers()
 {
 	int timerWidgetCount = ui->timerMainLayout->count();
 	for (int i = 0; i < timerWidgetCount; i++) {
-		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(
-			ui->timerMainLayout->itemAt(i)->widget());
+		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(ui->timerMainLayout->itemAt(i)->widget());
 		if (timerWidget) {
 			timerWidget->StartTimer();
 		}
@@ -651,8 +562,7 @@ void CountdownDockWidget::StopAllTimers()
 {
 	int timerWidgetCount = ui->timerMainLayout->count();
 	for (int i = 0; i < timerWidgetCount; i++) {
-		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(
-			ui->timerMainLayout->itemAt(i)->widget());
+		AshmanixTimer *timerWidget = static_cast<AshmanixTimer *>(ui->timerMainLayout->itemAt(i)->widget());
 		if (timerWidget) {
 			timerWidget->StopTimer();
 		}

--- a/src/countdown-widget.cpp
+++ b/src/countdown-widget.cpp
@@ -360,24 +360,10 @@ void CountdownDockWidget::ChangeTimerTimeViaWebsocket(obs_data_t *request_data, 
 		AshmanixTimer *timer = AttemptToGetTimerWidgetById(countdownWidget, websocketTimerID);
 
 		if (timer != nullptr) {
-			long long timeInMillis = ConvertStringPeriodToMillis(websocketDataTime);
-
-			obs_log(LOG_INFO, "Time in millis: %ld", timeInMillis);
-
-			// if (timeInMillis > 0) {
 			bool result = timer->AlterTime(requestType, websocketDataTime);
 			const char *type_string = requestType == ADD_TIME ? "added" : "set";
 			obs_log(LOG_INFO, "Time %s due to websocket call: %s", type_string, websocketDataTime);
 			obs_data_set_bool(response_data, "success", result);
-			// } else {
-			// 	obs_log(LOG_WARNING,
-			// 		"Timer time NOT changed from websocket request.");
-			// 	obs_data_set_bool(response_data, "success",
-			// 			  false);
-			// 	obs_data_set_string(
-			// 		response_data, "message",
-			// 		"Timer time wasn't changed. Ensure time is in format \"dd:hh:mm:ss\"");
-			// }
 		} else {
 			obs_log(LOG_WARNING, "Countdown widget not found for websocket request!");
 			obs_data_set_bool(response_data, "success", false);

--- a/src/countdown-widget.hpp
+++ b/src/countdown-widget.hpp
@@ -114,7 +114,6 @@ private:
 						      void *priv_data);
 
 signals:
-	void RequestTimerReset();
 
 private slots:
 	void RemoveTimerButtonClicked(QString id);

--- a/src/countdown-widget.hpp
+++ b/src/countdown-widget.hpp
@@ -79,12 +79,9 @@ private:
 	int startAllTimersHotkeyId = -1;
 	int stopAllTimersHotkeyId = -1;
 
-	static inline const char *addTimerHotkeyName =
-		"Ashmanix_Countdown_Timer_Add_Timer";
-	static inline const char *startAllTimersHotkeyName =
-		"Ashmanix_Countdown_Timer_Start_All_Timers";
-	static inline const char *stopAllTimersHotkeyName =
-		"Ashmanix_Countdown_Timer_Stop_All_Timers";
+	static inline const char *addTimerHotkeyName = "Ashmanix_Countdown_Timer_Add_Timer";
+	static inline const char *startAllTimersHotkeyName = "Ashmanix_Countdown_Timer_Start_All_Timers";
+	static inline const char *stopAllTimersHotkeyName = "Ashmanix_Countdown_Timer_Stop_All_Timers";
 
 	enum SourceType { TEXT_SOURCE = 1, SCENE_SOURCE = 2 };
 
@@ -104,25 +101,16 @@ private:
 	void AddTimer(obs_data_t *savedData = nullptr);
 	void UpdateTimerListMoveButtonState();
 	void ToggleUIForMultipleTimers();
-	static void
-	StartTimersOnStreamStart(CountdownDockWidget *countdownDockWidget);
-	static void
-	UpdateWidgetStyles(CountdownDockWidget *countdownDockWidget);
+	static void StartTimersOnStreamStart(CountdownDockWidget *countdownDockWidget);
+	static void UpdateWidgetStyles(CountdownDockWidget *countdownDockWidget);
 
-	static void OBSFrontendEventHandler(enum obs_frontend_event event,
-					    void *private_data);
+	static void OBSFrontendEventHandler(enum obs_frontend_event event, void *private_data);
 	static void LoadSavedSettings(CountdownDockWidget *timerWidgetMap);
-	static AshmanixTimer *
-	AttemptToGetTimerWidgetById(CountdownDockWidget *countdownWidget,
-				    const char *websocketTimerID);
-	static void ChangeTimerTimeViaWebsocket(obs_data_t *request_data,
-						obs_data_t *response_data,
-						void *priv_data);
-	static void GetTimerStateViaWebsocket(obs_data_t *request_data,
-					      obs_data_t *response_data,
-					      void *priv_data);
-	static void HandleWebsocketButtonPressRequest(obs_data_t *request_data,
-						      obs_data_t *response_data,
+	static AshmanixTimer *AttemptToGetTimerWidgetById(CountdownDockWidget *countdownWidget,
+							  const char *websocketTimerID);
+	static void ChangeTimerTimeViaWebsocket(obs_data_t *request_data, obs_data_t *response_data, void *priv_data);
+	static void GetTimerStateViaWebsocket(obs_data_t *request_data, obs_data_t *response_data, void *priv_data);
+	static void HandleWebsocketButtonPressRequest(obs_data_t *request_data, obs_data_t *response_data,
 						      void *priv_data);
 
 signals:
@@ -131,8 +119,7 @@ signals:
 private slots:
 	void RemoveTimerButtonClicked(QString id);
 	void AddTimerButtonClicked();
-	void HandleWebsocketSendEvent(const char *eventName,
-				      obs_data_t *eventData);
+	void HandleWebsocketSendEvent(const char *eventName, obs_data_t *eventData);
 	void MoveTimerInList(QString direction, QString id);
 	void StartAllTimers();
 	void StopAllTimers();

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -33,18 +33,14 @@ CountdownDockWidget *countdownWidget = nullptr;
 
 bool obs_module_load(void)
 {
-	const auto main_window =
-		static_cast<QMainWindow *>(obs_frontend_get_main_window());
+	const auto main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
 	obs_frontend_push_ui_translation(obs_module_get_string);
 	countdownWidget = new CountdownDockWidget(main_window);
 
-	obs_frontend_add_dock_by_id("ashmanixCountdownWidget",
-				    obs_module_text("CountdownTimer"),
-				    countdownWidget);
+	obs_frontend_add_dock_by_id("ashmanixCountdownWidget", obs_module_text("CountdownTimer"), countdownWidget);
 	obs_frontend_pop_ui_translation();
 
-	obs_log(LOG_INFO, "plugin loaded successfully (version %s)",
-		PLUGIN_VERSION);
+	obs_log(LOG_INFO, "plugin loaded successfully (version %s)", PLUGIN_VERSION);
 	return true;
 }
 

--- a/src/ui/AshmanixTimer.ui
+++ b/src/ui/AshmanixTimer.ui
@@ -489,6 +489,9 @@
                       <property name="alignment">
                        <set>Qt::AlignCenter</set>
                       </property>
+                      <property name="displayFormat">
+                       <string>dd/MM/yyyy HH:mm:ss</string>
+                      </property>
                       <property name="calendarPopup">
                        <bool>true</bool>
                       </property>

--- a/src/utils/obs-utils.cpp
+++ b/src/utils/obs-utils.cpp
@@ -1,20 +1,17 @@
 #include "obs-utils.hpp"
 
-void LoadHotkey(int &id, const char *name, const char *description,
-		std::function<void()> function, std::string buttonLogMessage,
-		obs_data_t *savedData = nullptr)
+void LoadHotkey(int &id, const char *name, const char *description, std::function<void()> function,
+		std::string buttonLogMessage, obs_data_t *savedData = nullptr)
 {
 
-	id = (int)obs_hotkey_register_frontend(
-		name, description, (obs_hotkey_func)HotkeyCallback,
-		new RegisterHotkeyCallbackData{function, buttonLogMessage});
+	id = (int)obs_hotkey_register_frontend(name, description, (obs_hotkey_func)HotkeyCallback,
+					       new RegisterHotkeyCallbackData{function, buttonLogMessage});
 
 	if (savedData) {
 		if ((int)id == -1)
 			return;
 
-		OBSDataArrayAutoRelease array =
-			obs_data_get_array(savedData, name);
+		OBSDataArrayAutoRelease array = obs_data_get_array(savedData, name);
 
 		obs_hotkey_load(id, array);
 	}
@@ -29,18 +26,14 @@ void SaveHotkey(obs_data_t *sv_data, obs_hotkey_id id, const char *name)
 	obs_data_set_array(sv_data, name, array);
 };
 
-void HotkeyCallback(void *incoming_data, obs_hotkey_id id, obs_hotkey_t *hotkey,
-		    bool pressed)
+void HotkeyCallback(void *incoming_data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
 {
 	UNUSED_PARAMETER(id);
 	UNUSED_PARAMETER(hotkey);
 	if (pressed) {
 		RegisterHotkeyCallbackData *hotkey_callback_data =
-			static_cast<RegisterHotkeyCallbackData *>(
-				incoming_data);
-		obs_log(LOG_INFO,
-			hotkey_callback_data->hotkeyLogMessage.c_str(),
-			" due to hotkey");
+			static_cast<RegisterHotkeyCallbackData *>(incoming_data);
+		obs_log(LOG_INFO, hotkey_callback_data->hotkeyLogMessage.c_str(), " due to hotkey");
 		hotkey_callback_data->function();
 	}
 }

--- a/src/utils/obs-utils.hpp
+++ b/src/utils/obs-utils.hpp
@@ -12,15 +12,13 @@ Q_DECLARE_OPAQUE_POINTER(obs_data_t *)
 
 struct RegisterHotkeyCallbackData {
 	std::function<void()> function; // Function pointer to callback function
-	std::string hotkeyLogMessage; // Message to log when hotkey is triggered
+	std::string hotkeyLogMessage;   // Message to log when hotkey is triggered
 };
 
-void LoadHotkey(int &id, const char *name, const char *description,
-		std::function<void()> function, std::string buttonLogMessage,
-		obs_data_t *savedData);
+void LoadHotkey(int &id, const char *name, const char *description, std::function<void()> function,
+		std::string buttonLogMessage, obs_data_t *savedData);
 
 void SaveHotkey(obs_data_t *sv_data, obs_hotkey_id id, const char *name);
-void HotkeyCallback(void *incoming_data, obs_hotkey_id id, obs_hotkey_t *hotkey,
-		    bool pressed);
+void HotkeyCallback(void *incoming_data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed);
 
 #endif // OBSUTILS_H

--- a/src/utils/timer-utils.cpp
+++ b/src/utils/timer-utils.cpp
@@ -7,7 +7,7 @@ const char *ConvertToConstChar(QString value)
 	return cString;
 }
 
-long long ConvertStringPeriodToMillis(const char *time_string)
+PeriodData ConvertStringPeriodToPeriodData(const char *time_string)
 {
 	int days = 0, hours = 0, minutes = 0, seconds = 0;
 
@@ -29,24 +29,26 @@ long long ConvertStringPeriodToMillis(const char *time_string)
 		sscanf(time_string, "%d:%d:%d", &hours, &minutes, &seconds);
 		break;
 	case 4:
-		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes,
-		       &seconds);
+		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes, &seconds);
 		break;
 	default:
-		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes,
-		       &seconds);
+		sscanf(time_string, "%d:%d:%d:%d", &days, &hours, &minutes, &seconds);
 		break;
 	}
 
+	return {days, hours, minutes, seconds};
+}
+
+long long ConvertStringPeriodToMillis(const char *time_string)
+{
+	PeriodData periodData = ConvertStringPeriodToPeriodData(time_string);
+
 	// Convert each unit into milliseconds and sum them up
 	long long totalMilliseconds = 0;
-	totalMilliseconds +=
-		static_cast<long long>(days) * 86400000; // 24 * 60 * 60 * 1000
-	totalMilliseconds +=
-		static_cast<long long>(hours) * 3600000; // 60 * 60 * 1000
-	totalMilliseconds +=
-		static_cast<long long>(minutes) * 60000; // 60 * 1000
-	totalMilliseconds += static_cast<long long>(seconds) * 1000; // 1000
+	totalMilliseconds += static_cast<long long>(periodData.days) * 86400000; // 24 * 60 * 60 * 1000
+	totalMilliseconds += static_cast<long long>(periodData.hours) * 3600000; // 60 * 60 * 1000
+	totalMilliseconds += static_cast<long long>(periodData.minutes) * 60000; // 60 * 1000
+	totalMilliseconds += static_cast<long long>(periodData.seconds) * 1000;  // 1000
 	return totalMilliseconds;
 }
 
@@ -55,8 +57,7 @@ QString ConvertMillisToDateTimeString(long long timeInMillis)
 	long long days = timeInMillis / (24 * 60 * 60 * 1000);
 	long long remainingMilliseconds = timeInMillis % (24 * 60 * 60 * 1000);
 
-	QTime time = QTime::fromMSecsSinceStartOfDay(
-		static_cast<int>(remainingMilliseconds));
+	QTime time = QTime::fromMSecsSinceStartOfDay(static_cast<int>(remainingMilliseconds));
 
 	return QString("%1:%2:%3:%4")
 		.arg(days, 2, 10, QChar('0'))        // Days with leading zeros
@@ -67,15 +68,13 @@ QString ConvertMillisToDateTimeString(long long timeInMillis)
 		     QChar('0')); // Seconds with leading zeros
 }
 
-QString GetFormattedTimerString(bool daysState, bool hoursState,
-				bool minutesState, bool secondsState,
+QString GetFormattedTimerString(bool daysState, bool hoursState, bool minutesState, bool secondsState,
 				bool showLeadingZero, long long timeInMillis)
 {
 	long long days = timeInMillis / (24 * 60 * 60 * 1000);
 	long long remainingMilliseconds = timeInMillis % (24 * 60 * 60 * 1000);
 
-	QTime time = QTime::fromMSecsSinceStartOfDay(
-		static_cast<int>(remainingMilliseconds));
+	QTime time = QTime::fromMSecsSinceStartOfDay(static_cast<int>(remainingMilliseconds));
 
 	QString formattedDateTimeString = "";
 
@@ -85,12 +84,10 @@ QString GetFormattedTimerString(bool daysState, bool hoursState,
 		if (state) {
 			if (isFirstField && !showLeadingZero) {
 				// Append without leading zero
-				formattedDateTimeString +=
-					QString::number(value);
+				formattedDateTimeString += QString::number(value);
 			} else {
 				// Append with leading zero
-				formattedDateTimeString += QString("%1").arg(
-					value, 2, 10, QChar('0'));
+				formattedDateTimeString += QString("%1").arg(value, 2, 10, QChar('0'));
 			}
 			isFirstField = false;
 		}
@@ -110,16 +107,13 @@ QString GetFormattedTimerString(bool daysState, bool hoursState,
 	return formattedDateTimeString;
 }
 
-long long CalcToCurrentDateTimeInMillis(QDateTime timeToCountdownTo,
-					int countdownPeriod)
+long long CalcToCurrentDateTimeInMillis(QDateTime timeToCountdownTo, int countdownPeriod)
 {
 	QDateTime systemTime = QDateTime::currentDateTime();
-	long long millisecondsDifference =
-		systemTime.msecsTo(timeToCountdownTo);
+	long long millisecondsDifference = systemTime.msecsTo(timeToCountdownTo);
 	long long millisResult = 0;
 
-	millisecondsDifference = millisecondsDifference +
-				 countdownPeriod; // Add 1 second for countdown
+	millisecondsDifference = millisecondsDifference + countdownPeriod; // Add 1 second for countdown
 
 	if (millisecondsDifference > 0) {
 		millisResult = millisecondsDifference;

--- a/src/utils/timer-utils.cpp
+++ b/src/utils/timer-utils.cpp
@@ -39,6 +39,20 @@ PeriodData ConvertStringPeriodToPeriodData(const char *time_string)
 	return {days, hours, minutes, seconds};
 }
 
+PeriodData ConvertMillisToPeriodData(long long timeInMillis) {
+	int days = 0, hours = 0, minutes = 0, seconds = 0;
+		long long daysFromMillis = timeInMillis / (24 * 60 * 60 * 1000);
+	long long remainingMilliseconds = timeInMillis % (24 * 60 * 60 * 1000);
+
+	QTime time = QTime::fromMSecsSinceStartOfDay(static_cast<int>(remainingMilliseconds));
+	days = static_cast<int>(daysFromMillis);
+	hours = time.hour();
+	minutes = time.minute();
+	seconds = time.second();
+
+	return {days, hours, minutes, seconds};
+}
+
 long long ConvertStringPeriodToMillis(const char *time_string)
 {
 	PeriodData periodData = ConvertStringPeriodToPeriodData(time_string);

--- a/src/utils/timer-utils.cpp
+++ b/src/utils/timer-utils.cpp
@@ -39,9 +39,10 @@ PeriodData ConvertStringPeriodToPeriodData(const char *time_string)
 	return {days, hours, minutes, seconds};
 }
 
-PeriodData ConvertMillisToPeriodData(long long timeInMillis) {
+PeriodData ConvertMillisToPeriodData(long long timeInMillis)
+{
 	int days = 0, hours = 0, minutes = 0, seconds = 0;
-		long long daysFromMillis = timeInMillis / (24 * 60 * 60 * 1000);
+	long long daysFromMillis = timeInMillis / (24 * 60 * 60 * 1000);
 	long long remainingMilliseconds = timeInMillis % (24 * 60 * 60 * 1000);
 
 	QTime time = QTime::fromMSecsSinceStartOfDay(static_cast<int>(remainingMilliseconds));

--- a/src/utils/timer-utils.hpp
+++ b/src/utils/timer-utils.hpp
@@ -74,6 +74,7 @@ struct Result {
 
 const char *ConvertToConstChar(QString value);
 PeriodData ConvertStringPeriodToPeriodData(const char *time_string);
+PeriodData ConvertMillisToPeriodData(long long timeInMillis);
 long long ConvertStringPeriodToMillis(const char *time_string);
 QString ConvertMillisToDateTimeString(long long timeInMillis);
 QString GetFormattedTimerString(bool daysState, bool hoursState, bool minutesState, bool secondsState,

--- a/src/utils/timer-utils.hpp
+++ b/src/utils/timer-utils.hpp
@@ -60,18 +60,24 @@ struct TimerWidgetStruct {
 	QWidget *datetimeVLayout;
 };
 
+struct PeriodData {
+	int days;
+	int hours;
+	int minutes;
+	int seconds;
+};
+
 struct Result {
 	bool success;
 	QString errorMessage;
 };
 
 const char *ConvertToConstChar(QString value);
+PeriodData ConvertStringPeriodToPeriodData(const char *time_string);
 long long ConvertStringPeriodToMillis(const char *time_string);
 QString ConvertMillisToDateTimeString(long long timeInMillis);
-QString GetFormattedTimerString(bool daysState, bool hoursState,
-				bool minutesState, bool secondsState,
+QString GetFormattedTimerString(bool daysState, bool hoursState, bool minutesState, bool secondsState,
 				bool showLeadingZero, long long timeInMillis);
-long long CalcToCurrentDateTimeInMillis(QDateTime timeToCountdownTo,
-					int countdownPeriod = 1000);
+long long CalcToCurrentDateTimeInMillis(QDateTime timeToCountdownTo, int countdownPeriod = 1000);
 
 #endif // TIMERUTILS_H

--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -307,8 +307,7 @@ bool AshmanixTimer::SetTime(const char *stringTime, bool isCountingUp)
 
 	bool result = false;
 	QDateTime currentDateTime = QDateTime::currentDateTime();
-	long long timeToAdd = countdownTimerData.shouldCountUp ? -(timeInMillis)
-							       : (timeInMillis + TIMERPERIOD);
+	long long timeToAdd = countdownTimerData.shouldCountUp ? -(timeInMillis) : (timeInMillis + TIMERPERIOD);
 	countdownTimerData.timeLeftInMillis = std::max((timeInMillis), 0ll);
 
 	if (countdownTimerData.selectedCountdownType == PERIOD) {

--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -1,8 +1,7 @@
 #include "ashmanix-timer.hpp"
 #include "settings-dialog.hpp"
 
-AshmanixTimer::AshmanixTimer(QWidget *parent, obs_websocket_vendor newVendor,
-			     obs_data_t *savedData,
+AshmanixTimer::AshmanixTimer(QWidget *parent, obs_websocket_vendor newVendor, obs_data_t *savedData,
 			     CountdownDockWidget *mDockWidget)
 	: QWidget(parent),
 	  ui(new Ui::AshmanixTimer)
@@ -24,10 +23,9 @@ AshmanixTimer::AshmanixTimer(QWidget *parent, obs_websocket_vendor newVendor,
 	if (countdownTimerData.timerId.size() == 0) {
 		// Create a unique ID for the timer
 		QUuid uuid = QUuid::createUuid();
-		QByteArray hash = QCryptographicHash::hash(
-			uuid.toByteArray(), QCryptographicHash::Md5);
-		countdownTimerData.timerId = QString(hash.toHex().left(
-			8)); // We take the first 8 characters of the hash
+		QByteArray hash = QCryptographicHash::hash(uuid.toByteArray(), QCryptographicHash::Md5);
+		countdownTimerData.timerId =
+			QString(hash.toHex().left(8)); // We take the first 8 characters of the hash
 	}
 
 	this->setProperty("id", countdownTimerData.timerId);
@@ -51,89 +49,54 @@ AshmanixTimer::~AshmanixTimer()
 
 void AshmanixTimer::SaveTimerWidgetDataToOBSSaveData(obs_data_t *dataObject)
 {
-	obs_data_set_string(dataObject, "timerId",
-			    countdownTimerData.timerId.toStdString().c_str());
-	obs_data_set_bool(dataObject, "startOnStreamStart",
-			  countdownTimerData.startOnStreamStart);
-	obs_data_set_bool(dataObject, "shouldCountUp",
-			  countdownTimerData.shouldCountUp);
-	obs_data_set_bool(dataObject, "showLeadingZero",
-			  countdownTimerData.showLeadingZero);
+	obs_data_set_string(dataObject, "timerId", countdownTimerData.timerId.toStdString().c_str());
+	obs_data_set_bool(dataObject, "startOnStreamStart", countdownTimerData.startOnStreamStart);
+	obs_data_set_bool(dataObject, "shouldCountUp", countdownTimerData.shouldCountUp);
+	obs_data_set_bool(dataObject, "showLeadingZero", countdownTimerData.showLeadingZero);
 
-	obs_data_set_string(
-		dataObject, "selectedSource",
-		countdownTimerData.selectedSource.toStdString().c_str());
-	obs_data_set_string(
-		dataObject, "selectedScene",
-		countdownTimerData.selectedScene.toStdString().c_str());
-	obs_data_set_string(
-		dataObject, "endMessage",
-		countdownTimerData.endMessage.toStdString().c_str());
-	obs_data_set_string(
-		dataObject, "dateTime",
-		countdownTimerData.dateTime.toString().toStdString().c_str());
+	obs_data_set_string(dataObject, "selectedSource", countdownTimerData.selectedSource.toStdString().c_str());
+	obs_data_set_string(dataObject, "selectedScene", countdownTimerData.selectedScene.toStdString().c_str());
+	obs_data_set_string(dataObject, "endMessage", countdownTimerData.endMessage.toStdString().c_str());
+	obs_data_set_string(dataObject, "dateTime", countdownTimerData.dateTime.toString().toStdString().c_str());
 
-	obs_data_set_int(dataObject, "periodDays",
-			 countdownTimerData.periodDays);
-	obs_data_set_int(dataObject, "periodHours",
-			 countdownTimerData.periodHours);
-	obs_data_set_int(dataObject, "periodMinutes",
-			 countdownTimerData.periodMinutes);
-	obs_data_set_int(dataObject, "periodSeconds",
-			 countdownTimerData.periodSeconds);
+	obs_data_set_int(dataObject, "periodDays", countdownTimerData.periodDays);
+	obs_data_set_int(dataObject, "periodHours", countdownTimerData.periodHours);
+	obs_data_set_int(dataObject, "periodMinutes", countdownTimerData.periodMinutes);
+	obs_data_set_int(dataObject, "periodSeconds", countdownTimerData.periodSeconds);
 
 	obs_data_set_bool(dataObject, "showDays", countdownTimerData.showDays);
-	obs_data_set_bool(dataObject, "showHours",
-			  countdownTimerData.showHours);
-	obs_data_set_bool(dataObject, "showMinutes",
-			  countdownTimerData.showMinutes);
-	obs_data_set_bool(dataObject, "showSeconds",
-			  countdownTimerData.showSeconds);
-	obs_data_set_bool(dataObject, "showEndMessage",
-			  countdownTimerData.showEndMessage);
-	obs_data_set_bool(dataObject, "showEndScene",
-			  countdownTimerData.showEndScene);
+	obs_data_set_bool(dataObject, "showHours", countdownTimerData.showHours);
+	obs_data_set_bool(dataObject, "showMinutes", countdownTimerData.showMinutes);
+	obs_data_set_bool(dataObject, "showSeconds", countdownTimerData.showSeconds);
+	obs_data_set_bool(dataObject, "showEndMessage", countdownTimerData.showEndMessage);
+	obs_data_set_bool(dataObject, "showEndScene", countdownTimerData.showEndScene);
 
-	obs_data_set_int(dataObject, "selectedCountdownType",
-			 countdownTimerData.selectedCountdownType);
+	obs_data_set_int(dataObject, "selectedCountdownType", countdownTimerData.selectedCountdownType);
 
 	// ------------------------- Hotkeys -------------------------
-	SaveHotkey(dataObject, countdownTimerData.startCountdownHotkeyId,
-		   TIMERSTARTHOTKEYNAME);
+	SaveHotkey(dataObject, countdownTimerData.startCountdownHotkeyId, TIMERSTARTHOTKEYNAME);
 
-	SaveHotkey(dataObject, countdownTimerData.pauseCountdownHotkeyId,
-		   TIMERPAUSEHOTKEYNAME);
+	SaveHotkey(dataObject, countdownTimerData.pauseCountdownHotkeyId, TIMERPAUSEHOTKEYNAME);
 
-	SaveHotkey(dataObject, countdownTimerData.setCountdownHotkeyId,
-		   TIMERSETHOTKEYNAME);
+	SaveHotkey(dataObject, countdownTimerData.setCountdownHotkeyId, TIMERSETHOTKEYNAME);
 
-	SaveHotkey(dataObject, countdownTimerData.startCountdownToTimeHotkeyId,
-		   TIMERTOTIMESTARTHOTKEYNAME);
+	SaveHotkey(dataObject, countdownTimerData.startCountdownToTimeHotkeyId, TIMERTOTIMESTARTHOTKEYNAME);
 
-	SaveHotkey(dataObject, countdownTimerData.stopCountdownToTimeHotkeyId,
-		   TIMERTOTIMESTOPHOTKEYNAME);
+	SaveHotkey(dataObject, countdownTimerData.stopCountdownToTimeHotkeyId, TIMERTOTIMESTOPHOTKEYNAME);
 }
 
 void AshmanixTimer::LoadTimerWidgetDataFromOBSSaveData(obs_data_t *dataObject)
 {
 
-	countdownTimerData.timerId =
-		(char *)obs_data_get_string(dataObject, "timerId");
-	countdownTimerData.startOnStreamStart =
-		(bool)obs_data_get_bool(dataObject, "startOnStreamStart");
-	countdownTimerData.shouldCountUp =
-		(bool)obs_data_get_bool(dataObject, "shouldCountUp");
-	countdownTimerData.showLeadingZero =
-		(bool)obs_data_get_bool(dataObject, "showLeadingZero");
-	countdownTimerData.selectedSource =
-		(char *)obs_data_get_string(dataObject, "selectedSource");
-	countdownTimerData.selectedScene =
-		(char *)obs_data_get_string(dataObject, "selectedScene");
-	countdownTimerData.endMessage =
-		(char *)obs_data_get_string(dataObject, "endMessage");
+	countdownTimerData.timerId = (char *)obs_data_get_string(dataObject, "timerId");
+	countdownTimerData.startOnStreamStart = (bool)obs_data_get_bool(dataObject, "startOnStreamStart");
+	countdownTimerData.shouldCountUp = (bool)obs_data_get_bool(dataObject, "shouldCountUp");
+	countdownTimerData.showLeadingZero = (bool)obs_data_get_bool(dataObject, "showLeadingZero");
+	countdownTimerData.selectedSource = (char *)obs_data_get_string(dataObject, "selectedSource");
+	countdownTimerData.selectedScene = (char *)obs_data_get_string(dataObject, "selectedScene");
+	countdownTimerData.endMessage = (char *)obs_data_get_string(dataObject, "endMessage");
 
-	QDateTime savedTime = QDateTime::fromString(
-		(char *)obs_data_get_string(dataObject, "dateTime"));
+	QDateTime savedTime = QDateTime::fromString((char *)obs_data_get_string(dataObject, "dateTime"));
 	QDateTime currentTime = QDateTime::currentDateTime();
 	if (currentTime > savedTime) {
 		savedTime = savedTime.addDays(1);
@@ -142,40 +105,25 @@ void AshmanixTimer::LoadTimerWidgetDataFromOBSSaveData(obs_data_t *dataObject)
 	}
 	countdownTimerData.dateTime = savedTime;
 
-	countdownTimerData.periodDays =
-		(int)obs_data_get_int(dataObject, "periodDays");
-	countdownTimerData.periodHours =
-		(int)obs_data_get_int(dataObject, "periodHours");
-	countdownTimerData.periodMinutes =
-		(int)obs_data_get_int(dataObject, "periodMinutes");
-	countdownTimerData.periodSeconds =
-		(int)obs_data_get_int(dataObject, "periodSeconds");
+	countdownTimerData.periodDays = (int)obs_data_get_int(dataObject, "periodDays");
+	countdownTimerData.periodHours = (int)obs_data_get_int(dataObject, "periodHours");
+	countdownTimerData.periodMinutes = (int)obs_data_get_int(dataObject, "periodMinutes");
+	countdownTimerData.periodSeconds = (int)obs_data_get_int(dataObject, "periodSeconds");
 
-	countdownTimerData.showDays =
-		(bool)obs_data_get_bool(dataObject, "showDays");
-	countdownTimerData.showHours =
-		(bool)obs_data_get_bool(dataObject, "showHours");
-	countdownTimerData.showMinutes =
-		(bool)obs_data_get_bool(dataObject, "showMinutes");
-	countdownTimerData.showSeconds =
-		(bool)obs_data_get_bool(dataObject, "showSeconds");
-	countdownTimerData.showEndMessage =
-		(bool)obs_data_get_bool(dataObject, "showEndMessage");
-	countdownTimerData.showEndScene =
-		(bool)obs_data_get_bool(dataObject, "showEndScene");
-	countdownTimerData.selectedCountdownType =
-		(CountdownType)obs_data_get_int(dataObject,
-						"selectedCountdownType");
-	countdownTimerData.startCountdownHotkeyId =
-		(int)obs_data_get_int(dataObject, "startCountdownHotkeyId");
-	countdownTimerData.pauseCountdownHotkeyId =
-		(int)obs_data_get_int(dataObject, "pauseCountdownHotkeyId");
-	countdownTimerData.setCountdownHotkeyId =
-		(int)obs_data_get_int(dataObject, "setCountdownHotkeyId");
-	countdownTimerData.startCountdownToTimeHotkeyId = (int)obs_data_get_int(
-		dataObject, "startCountdownToTimeHotkeyId");
-	countdownTimerData.stopCountdownToTimeHotkeyId = (int)obs_data_get_int(
-		dataObject, "stopCountdownToTimeHotkeyId");
+	countdownTimerData.showDays = (bool)obs_data_get_bool(dataObject, "showDays");
+	countdownTimerData.showHours = (bool)obs_data_get_bool(dataObject, "showHours");
+	countdownTimerData.showMinutes = (bool)obs_data_get_bool(dataObject, "showMinutes");
+	countdownTimerData.showSeconds = (bool)obs_data_get_bool(dataObject, "showSeconds");
+	countdownTimerData.showEndMessage = (bool)obs_data_get_bool(dataObject, "showEndMessage");
+	countdownTimerData.showEndScene = (bool)obs_data_get_bool(dataObject, "showEndScene");
+	countdownTimerData.selectedCountdownType = (CountdownType)obs_data_get_int(dataObject, "selectedCountdownType");
+	countdownTimerData.startCountdownHotkeyId = (int)obs_data_get_int(dataObject, "startCountdownHotkeyId");
+	countdownTimerData.pauseCountdownHotkeyId = (int)obs_data_get_int(dataObject, "pauseCountdownHotkeyId");
+	countdownTimerData.setCountdownHotkeyId = (int)obs_data_get_int(dataObject, "setCountdownHotkeyId");
+	countdownTimerData.startCountdownToTimeHotkeyId =
+		(int)obs_data_get_int(dataObject, "startCountdownToTimeHotkeyId");
+	countdownTimerData.stopCountdownToTimeHotkeyId =
+		(int)obs_data_get_int(dataObject, "stopCountdownToTimeHotkeyId");
 
 	SetTimerData();
 }
@@ -226,69 +174,146 @@ void AshmanixTimer::SetIsDownButtonDisabled(bool isDisabled)
 
 void AshmanixTimer::SetTimerData()
 {
-	ui->timerNameLabel->setText(
-		QString("Timer: %1").arg(countdownTimerData.timerId));
+	ui->timerNameLabel->setText(QString("Timer: %1").arg(countdownTimerData.timerId));
 
 	ui->dateTimeEdit->setDateTime(countdownTimerData.dateTime);
 
 	ui->timerDays->setText(QString::number(countdownTimerData.periodDays));
-	ui->timerHours->setText(
-		QString::number(countdownTimerData.periodHours));
-	ui->timerMinutes->setText(
-		QString::number(countdownTimerData.periodMinutes));
-	ui->timerSeconds->setText(
-		QString::number(countdownTimerData.periodSeconds));
+	ui->timerHours->setText(QString::number(countdownTimerData.periodHours));
+	ui->timerMinutes->setText(QString::number(countdownTimerData.periodMinutes));
+	ui->timerSeconds->setText(QString::number(countdownTimerData.periodSeconds));
 
-	ui->timerNameLabel->setText(
-		QString("Timer: %1").arg(countdownTimerData.timerId));
+	ui->timerNameLabel->setText(QString("Timer: %1").arg(countdownTimerData.timerId));
 	InitialiseTimerTime();
 }
 
-bool AshmanixTimer::AlterTime(WebsocketRequestType requestType,
-			      long long timeInMillis)
+bool AshmanixTimer::AlterTime(WebsocketRequestType requestType, const char *stringTime)
 {
 	bool result = false;
+	// QDateTime currentDateTime = QDateTime::currentDateTime();
+	// long long timeToAdd = countdownTimerData.shouldCountUp ? -timeInMillis
+	// 						       : timeInMillis;
+
+	switch (requestType) {
+	case ADD_TIME:
+		result = AddTime(stringTime, countdownTimerData.shouldCountUp);
+		break;
+	case SET_TIME:
+		result = SetTime(stringTime, countdownTimerData.shouldCountUp);
+		break;
+	default:
+		return false;
+		break;
+	}
+
+	// if (countdownTimerData.selectedCountdownType == PERIOD) {
+	// 	switch (requestType) {
+	// 	case ADD_TIME:
+	// 		countdownTimerData.timeAtTimerStart =
+	// 			countdownTimerData.timeAtTimerStart.addMSecs(
+	// 				timeToAdd);
+	// 		countdownTimerData.timeLeftInMillis =
+	// 			countdownTimerData.timeLeftInMillis +
+	// 			timeInMillis;
+	// 		break;
+	// 	case SET_TIME:
+	// 		countdownTimerData.timeAtTimerStart =
+	// 			currentDateTime.addMSecs(timeToAdd);
+	// 		break;
+	// 	default:
+	// 		return false;
+	// 		break;
+	// 	}
+
+	// 	UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
+	// 	result = true;
+	// } else if (countdownTimerData.selectedCountdownType == DATETIME) {
+	// 	QDateTime updatedDateTime;
+
+	// 	switch (requestType) {
+	// 	case ADD_TIME:
+	// 		updatedDateTime = ui->dateTimeEdit->dateTime().addMSecs(
+	// 			timeInMillis);
+	// 		ui->dateTimeEdit->setDateTime(updatedDateTime);
+	// 		break;
+	// 	case SET_TIME:
+	// 		updatedDateTime = QDateTime::currentDateTime().addMSecs(
+	// 			timeInMillis);
+	// 		ui->dateTimeEdit->setDateTime(updatedDateTime);
+	// 		break;
+	// 	default:
+	// 		return false;
+	// 		break;
+	// 	}
+	// 	long long new_time = CalcToCurrentDateTimeInMillis(
+	// 		ui->dateTimeEdit->dateTime(), TIMERPERIOD);
+	// 	UpdateDateTimeDisplay(new_time);
+	// 	result = true;
+	// }
+	UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
+	emit RequestTimerReset();
+	return result;
+}
+
+bool AshmanixTimer::AddTime(const char *stringTime, bool isCountingUp)
+{
+	bool result = false;
+	QDateTime currentDateTime = QDateTime::currentDateTime();
 
 	if (countdownTimerData.selectedCountdownType == PERIOD) {
-		switch (requestType) {
-		case ADD_TIME:
-			countdownTimerData.timeLeftInMillis += timeInMillis;
-			break;
-		case SET_TIME:
-			countdownTimerData.timeLeftInMillis = timeInMillis;
-			break;
-			break;
-		default:
-			return false;
-			break;
-		}
+		if (isCountingUp) {
+			PeriodData periodData = ConvertStringPeriodToPeriodData(stringTime);
+			countdownTimerData.periodDays = std::max((countdownTimerData.periodDays + periodData.days), 0);
+			countdownTimerData.periodHours =
+				std::max((countdownTimerData.periodHours + periodData.hours), 0);
+			countdownTimerData.periodMinutes =
+				std::max((countdownTimerData.periodMinutes + periodData.minutes), 0);
+			countdownTimerData.periodSeconds =
+				std::max((countdownTimerData.periodSeconds + periodData.seconds), 0);
 
-		UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
+			ui->timerDays->setText(QString::number(countdownTimerData.periodDays));
+			ui->timerHours->setText(QString::number(countdownTimerData.periodHours));
+			ui->timerMinutes->setText(QString::number(countdownTimerData.periodMinutes));
+			ui->timerSeconds->setText(QString::number(countdownTimerData.periodSeconds));
+
+			result = true;
+		} else {
+			long long timeInMillis = ConvertStringPeriodToMillis(stringTime);
+			countdownTimerData.timeAtTimerStart =
+				countdownTimerData.timeAtTimerStart.addMSecs(timeInMillis);
+			countdownTimerData.timeLeftInMillis =
+				std::max((countdownTimerData.timeLeftInMillis + timeInMillis), 0ll);
+			result = true;
+		}
+	} else if (countdownTimerData.selectedCountdownType == DATETIME) {
+		long long timeInMillis = ConvertStringPeriodToMillis(stringTime);
+		QDateTime updatedDateTime;
+		updatedDateTime = ui->dateTimeEdit->dateTime().addMSecs(timeInMillis);
+		ui->dateTimeEdit->setDateTime(updatedDateTime);
+		countdownTimerData.timeLeftInMillis =
+				std::max((countdownTimerData.timeLeftInMillis + timeInMillis), 0ll);
+		result = true;
+	}
+	return result;
+}
+
+bool AshmanixTimer::SetTime(const char *stringTime, bool isCountingUp)
+{
+	UNUSED_PARAMETER(isCountingUp);
+	bool result = false;
+	QDateTime currentDateTime = QDateTime::currentDateTime();
+	long long timeInMillis = ConvertStringPeriodToMillis(stringTime);
+	long long timeToAdd = countdownTimerData.shouldCountUp ? -timeInMillis : timeInMillis;
+	if (countdownTimerData.selectedCountdownType == PERIOD) {
+		countdownTimerData.timeAtTimerStart = currentDateTime.addMSecs(timeToAdd);
 		result = true;
 	} else if (countdownTimerData.selectedCountdownType == DATETIME) {
 		QDateTime updatedDateTime;
 
-		switch (requestType) {
-		case ADD_TIME:
-			updatedDateTime = ui->dateTimeEdit->dateTime().addMSecs(
-				timeInMillis);
-			ui->dateTimeEdit->setDateTime(updatedDateTime);
-			break;
-		case SET_TIME:
-			updatedDateTime = QDateTime::currentDateTime().addMSecs(
-				timeInMillis);
-			ui->dateTimeEdit->setDateTime(updatedDateTime);
-			break;
-		default:
-			return false;
-			break;
-		}
-		long long new_time = CalcToCurrentDateTimeInMillis(
-			ui->dateTimeEdit->dateTime(), TIMERPERIOD);
-		UpdateDateTimeDisplay(new_time);
+		updatedDateTime = QDateTime::currentDateTime().addMSecs(timeInMillis);
+		ui->dateTimeEdit->setDateTime(updatedDateTime);
 		result = true;
 	}
-	emit RequestTimerReset();
 	return result;
 }
 
@@ -320,48 +345,40 @@ void AshmanixTimer::PressToTimeStopButton()
 void AshmanixTimer::UpdateStyles()
 {
 	// Set toolbutton colour checked to darkened colour
-	QColor bgColor =
-		ui->periodToolButton->palette().color(QPalette::Button);
+	QColor bgColor = ui->periodToolButton->palette().color(QPalette::Button);
 	QColor darkenedColor = bgColor.darker(150);
-	this->setStyleSheet(
-		QString("QToolButton:checked { background-color: %1; } ")
-			.arg(darkenedColor.name()));
+	this->setStyleSheet(QString("QToolButton:checked { background-color: %1; } ").arg(darkenedColor.name()));
 }
 
 // --------------------------------- Private ----------------------------------
 
 void AshmanixTimer::SetupTimerWidgetUI()
 {
-	ui->timerNameLabel->setText(
-		QString("Timer: %1").arg(countdownTimerData.timerId));
+	ui->timerNameLabel->setText(QString("Timer: %1").arg(countdownTimerData.timerId));
 
 	ui->settingsToolButton->setProperty("themeID", "propertiesIconSmall");
 	ui->settingsToolButton->setProperty("class", "icon-gear");
 	ui->settingsToolButton->setText("");
 	ui->settingsToolButton->setEnabled(true);
-	ui->settingsToolButton->setToolTip(
-		obs_module_text("SettingsButtonTip"));
+	ui->settingsToolButton->setToolTip(obs_module_text("SettingsButtonTip"));
 
 	ui->deleteToolButton->setProperty("themeID", "removeIconSmall");
 	ui->deleteToolButton->setProperty("class", "icon-trash");
 	ui->deleteToolButton->setText("");
 	ui->deleteToolButton->setEnabled(true);
-	ui->deleteToolButton->setToolTip(
-		obs_module_text("DeleteTimerButtonTip"));
+	ui->deleteToolButton->setToolTip(obs_module_text("DeleteTimerButtonTip"));
 
 	ui->moveUpToolButton->setProperty("themeID", "upArrowIconSmall");
 	ui->moveUpToolButton->setProperty("class", "icon-up");
 	ui->moveUpToolButton->setText("");
 	ui->moveUpToolButton->setEnabled(true);
-	ui->moveUpToolButton->setToolTip(
-		obs_module_text("MoveTimerUpButtonTip"));
+	ui->moveUpToolButton->setToolTip(obs_module_text("MoveTimerUpButtonTip"));
 
 	ui->moveDownToolButton->setProperty("themeID", "downArrowIconSmall");
 	ui->moveDownToolButton->setProperty("class", "icon-down");
 	ui->moveDownToolButton->setText("");
 	ui->moveDownToolButton->setEnabled(true);
-	ui->moveDownToolButton->setToolTip(
-		obs_module_text("MoveTimerDownButtonTip"));
+	ui->moveDownToolButton->setToolTip(obs_module_text("MoveTimerDownButtonTip"));
 
 	ui->timeDisplay->display(AshmanixTimer::ZEROSTRING);
 
@@ -369,24 +386,21 @@ void AshmanixTimer::SetupTimerWidgetUI()
 	ui->dateTimeEdit->setMaximumDate(QDate::currentDate().addDays(999));
 
 	ui->timerDays->setMaxLength(3);
-	ui->timerDays->setValidator(new QRegularExpressionValidator(
-		QRegularExpression("^(0|[1-9]\\d{0,2})$"), this));
+	ui->timerDays->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0|[1-9]\\d{0,2})$"), this));
 	ui->timerDays->setToolTip(obs_module_text("DaysCheckboxLabel"));
 
 	ui->timerHours->setMaxLength(2);
-	ui->timerHours->setValidator(new QRegularExpressionValidator(
-		QRegularExpression("^(0?[0-9]|1[0-9]|2[0-3])$"), this));
+	ui->timerHours->setValidator(
+		new QRegularExpressionValidator(QRegularExpression("^(0?[0-9]|1[0-9]|2[0-3])$"), this));
 	ui->timerHours->setToolTip(obs_module_text("HoursCheckboxLabel"));
 
 	ui->timerMinutes->setMaxLength(2);
-	ui->timerMinutes->setValidator(new QRegularExpressionValidator(
-		QRegularExpression("^[1-5]?[0-9]"), this));
+	ui->timerMinutes->setValidator(new QRegularExpressionValidator(QRegularExpression("^[1-5]?[0-9]"), this));
 	ui->timerMinutes->setToolTip(obs_module_text("MinutesCheckboxLabel"));
 
 	ui->timerSeconds->setAlignment(Qt::AlignCenter);
 	ui->timerSeconds->setMaxLength(2);
-	ui->timerSeconds->setValidator(new QRegularExpressionValidator(
-		QRegularExpression("^[1-5]?[0-9]"), this));
+	ui->timerSeconds->setValidator(new QRegularExpressionValidator(QRegularExpression("^[1-5]?[0-9]"), this));
 	ui->timerSeconds->setToolTip(obs_module_text("SecondsCheckboxLabel"));
 
 	countdownTimerData.periodVLayout = ui->periodWidget;
@@ -394,8 +408,7 @@ void AshmanixTimer::SetupTimerWidgetUI()
 	ui->periodToolButton->setToolTip(obs_module_text("SetPeriodTabTip"));
 	countdownTimerData.datetimeVLayout = ui->datetimeWidget;
 	ui->datetimeToolButton->setText(obs_module_text("SetDatetimeTabLabel"));
-	ui->datetimeToolButton->setToolTip(
-		obs_module_text("SetDatetimeTabTip"));
+	ui->datetimeToolButton->setToolTip(obs_module_text("SetDatetimeTabTip"));
 	UpdateStyles();
 	ToggleTimeType(countdownTimerData.selectedCountdownType);
 
@@ -422,15 +435,13 @@ void AshmanixTimer::SetupTimerWidgetUI()
 	ui->toTimeStopButton->setProperty("themeID", "stopIcon");
 	ui->toTimeStopButton->setProperty("class", "icon-media-stop");
 	ui->toTimeStopButton->setEnabled(false);
-	ui->toTimeStopButton->setToolTip(
-		obs_module_text("ToTimeStopButtonTip"));
+	ui->toTimeStopButton->setToolTip(obs_module_text("ToTimeStopButtonTip"));
 
 	ui->frame->setProperty("class", "bg-base");
 
-	deleteButtonSpacer =
-		new QSpacerItem(ui->deleteToolButton->sizeHint().width(),
-				ui->deleteToolButton->sizeHint().height(),
-				QSizePolicy::Fixed, QSizePolicy::Fixed);
+	deleteButtonSpacer = new QSpacerItem(ui->deleteToolButton->sizeHint().width(),
+					     ui->deleteToolButton->sizeHint().height(), QSizePolicy::Fixed,
+					     QSizePolicy::Fixed);
 
 	UpdateTimeDisplayTooltip();
 
@@ -439,66 +450,46 @@ void AshmanixTimer::SetupTimerWidgetUI()
 
 void AshmanixTimer::ConnectUISignalHandlers()
 {
-	QObject::connect(ui->playButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::PlayButtonClicked);
+	QObject::connect(ui->playButton, &QPushButton::clicked, this, &AshmanixTimer::PlayButtonClicked);
 
-	QObject::connect(ui->pauseButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::PauseButtonClicked);
+	QObject::connect(ui->pauseButton, &QPushButton::clicked, this, &AshmanixTimer::PauseButtonClicked);
 
-	QObject::connect(ui->resetButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::ResetButtonClicked);
+	QObject::connect(ui->resetButton, &QPushButton::clicked, this, &AshmanixTimer::ResetButtonClicked);
 
-	QObject::connect(ui->toTimePlayButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::ToTimePlayButtonClicked);
+	QObject::connect(ui->toTimePlayButton, &QPushButton::clicked, this, &AshmanixTimer::ToTimePlayButtonClicked);
 
-	QObject::connect(ui->toTimeStopButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::ToTimeStopButtonClicked);
+	QObject::connect(ui->toTimeStopButton, &QPushButton::clicked, this, &AshmanixTimer::ToTimeStopButtonClicked);
 
-	QObject::connect(ui->deleteToolButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::DeleteButtonClicked);
+	QObject::connect(ui->deleteToolButton, &QPushButton::clicked, this, &AshmanixTimer::DeleteButtonClicked);
 
-	QObject::connect(ui->settingsToolButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::SettingsButtonClicked);
+	QObject::connect(ui->settingsToolButton, &QPushButton::clicked, this, &AshmanixTimer::SettingsButtonClicked);
 
-	QObject::connect(ui->timerDays, &QLineEdit::textChanged, this,
-			 &AshmanixTimer::DaysChanged);
+	QObject::connect(ui->timerDays, &QLineEdit::textChanged, this, &AshmanixTimer::DaysChanged);
 
-	QObject::connect(ui->timerHours, &QLineEdit::textChanged, this,
-			 &AshmanixTimer::HoursChanged);
+	QObject::connect(ui->timerHours, &QLineEdit::textChanged, this, &AshmanixTimer::HoursChanged);
 
-	QObject::connect(ui->timerMinutes, &QLineEdit::textChanged, this,
-			 &AshmanixTimer::MinutesChanged);
+	QObject::connect(ui->timerMinutes, &QLineEdit::textChanged, this, &AshmanixTimer::MinutesChanged);
 
-	QObject::connect(ui->timerSeconds, &QLineEdit::textChanged, this,
-			 &AshmanixTimer::SecondsChanged);
+	QObject::connect(ui->timerSeconds, &QLineEdit::textChanged, this, &AshmanixTimer::SecondsChanged);
 
-	QObject::connect(ui->dateTimeEdit, &QDateTimeEdit::dateTimeChanged,
-			 this, &AshmanixTimer::DateTimeChanged);
+	QObject::connect(ui->dateTimeEdit, &QDateTimeEdit::dateTimeChanged, this, &AshmanixTimer::DateTimeChanged);
 
-	QObject::connect(ui->moveUpToolButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::EmitMoveTimerUpSignal);
+	QObject::connect(ui->moveUpToolButton, &QPushButton::clicked, this, &AshmanixTimer::EmitMoveTimerUpSignal);
 
-	QObject::connect(ui->moveDownToolButton, &QPushButton::clicked, this,
-			 &AshmanixTimer::EmitMoveTimerDownSignal);
+	QObject::connect(ui->moveDownToolButton, &QPushButton::clicked, this, &AshmanixTimer::EmitMoveTimerDownSignal);
 
-	QObject::connect(ui->periodToolButton, &QPushButton::clicked, this,
-			 [this]() { ToggleTimeType(PERIOD); });
+	QObject::connect(ui->periodToolButton, &QPushButton::clicked, this, [this]() { ToggleTimeType(PERIOD); });
 
-	QObject::connect(ui->datetimeToolButton, &QPushButton::clicked, this,
-			 [this]() { ToggleTimeType(DATETIME); });
+	QObject::connect(ui->datetimeToolButton, &QPushButton::clicked, this, [this]() { ToggleTimeType(DATETIME); });
 }
 
-QString
-AshmanixTimer::ConvertDateTimeToFormattedDisplayString(long long timeInMillis,
-						       bool showLeadingZero)
+QString AshmanixTimer::ConvertDateTimeToFormattedDisplayString(long long timeInMillis, bool showLeadingZero)
 {
 	QString formattedDateTimeString = GetFormattedTimerString(
-		countdownTimerData.showDays, countdownTimerData.showHours,
-		countdownTimerData.showMinutes, countdownTimerData.showSeconds,
-		showLeadingZero, timeInMillis);
+		countdownTimerData.showDays, countdownTimerData.showHours, countdownTimerData.showMinutes,
+		countdownTimerData.showSeconds, showLeadingZero, timeInMillis);
 
-	return (formattedDateTimeString == "") ? "Nothing selected!"
-					       : formattedDateTimeString;
+	return (formattedDateTimeString == "") ? "Nothing selected!" : formattedDateTimeString;
 }
 
 void AshmanixTimer::StartTimerCounting()
@@ -556,8 +547,7 @@ void AshmanixTimer::StopTimerCounting()
 void AshmanixTimer::InitialiseTimerTime()
 {
 	countdownTimerData.timer = new QTimer();
-	QObject::connect(countdownTimerData.timer, SIGNAL(timeout()),
-			 SLOT(TimerAdjust()));
+	QObject::connect(countdownTimerData.timer, SIGNAL(timeout()), SLOT(TimerAdjust()));
 
 	countdownTimerData.timeLeftInMillis = GetMillisFromPeriodUI();
 }
@@ -568,10 +558,8 @@ bool AshmanixTimer::IsSetTimeZero()
 
 	if (countdownTimerData.timeLeftInMillis == 0) {
 		isZero = true;
-	} else if (ui->timerDays->text().toInt() == 0 &&
-		   ui->timerHours->text().toInt() == 0 &&
-		   ui->timerMinutes->text().toInt() == 0 &&
-		   ui->timerSeconds->text().toInt() == 0) {
+	} else if (ui->timerDays->text().toInt() == 0 && ui->timerHours->text().toInt() == 0 &&
+		   ui->timerMinutes->text().toInt() == 0 && ui->timerSeconds->text().toInt() == 0) {
 		isZero = true;
 	}
 
@@ -580,22 +568,20 @@ bool AshmanixTimer::IsSetTimeZero()
 
 void AshmanixTimer::UpdateDateTimeDisplay(long long timeInMillis)
 {
-	ui->timeDisplay->display(ConvertMillisToDateTimeString(timeInMillis));
-	QString formattedDisplayTime = ConvertDateTimeToFormattedDisplayString(
-		timeInMillis, countdownTimerData.showLeadingZero);
+	long long timeToUpdateInMillis = std::max(timeInMillis, 0ll);
+	ui->timeDisplay->display(ConvertMillisToDateTimeString(timeToUpdateInMillis));
+	QString formattedDisplayTime =
+		ConvertDateTimeToFormattedDisplayString(timeToUpdateInMillis, countdownTimerData.showLeadingZero);
 	SetSourceText(formattedDisplayTime);
 }
 
 void AshmanixTimer::SetSourceText(QString newText)
 {
-	obs_source_t *selectedSource = obs_get_source_by_name(
-		countdownTimerData.selectedSource.toStdString().c_str());
+	obs_source_t *selectedSource = obs_get_source_by_name(countdownTimerData.selectedSource.toStdString().c_str());
 
 	if (selectedSource != NULL) {
-		obs_data_t *sourceSettings =
-			obs_source_get_settings(selectedSource);
-		obs_data_set_string(sourceSettings, "text",
-				    newText.toStdString().c_str());
+		obs_data_t *sourceSettings = obs_source_get_settings(selectedSource);
+		obs_data_set_string(sourceSettings, "text", newText.toStdString().c_str());
 		obs_source_update(selectedSource, sourceSettings);
 		obs_data_release(sourceSettings);
 		obs_source_release(selectedSource);
@@ -605,8 +591,7 @@ void AshmanixTimer::SetSourceText(QString newText)
 void AshmanixTimer::SetCurrentScene()
 {
 	if (countdownTimerData.selectedScene.length()) {
-		obs_source_t *source = obs_get_source_by_name(
-			countdownTimerData.selectedScene.toStdString().c_str());
+		obs_source_t *source = obs_get_source_by_name(countdownTimerData.selectedScene.toStdString().c_str());
 		if (source != NULL) {
 			obs_frontend_set_current_scene(source);
 			obs_source_release(source);
@@ -616,34 +601,24 @@ void AshmanixTimer::SetCurrentScene()
 
 long long AshmanixTimer::GetMillisFromPeriodUI()
 {
-	long long days_ms =
-		static_cast<long long>(ui->timerDays->text().toInt()) * 24 *
-		60 * 60 * 1000;
-	long long hours_ms =
-		static_cast<long long>(ui->timerHours->text().toInt()) * 60 *
-		60 * 1000;
-	long long minutes_ms =
-		static_cast<long long>(ui->timerMinutes->text().toInt()) * 60 *
-		1000;
-	long long seconds_ms =
-		static_cast<long long>(ui->timerSeconds->text().toInt()) * 1000;
+	long long days_ms = static_cast<long long>(ui->timerDays->text().toInt()) * 24 * 60 * 60 * 1000;
+	long long hours_ms = static_cast<long long>(ui->timerHours->text().toInt()) * 60 * 60 * 1000;
+	long long minutes_ms = static_cast<long long>(ui->timerMinutes->text().toInt()) * 60 * 1000;
+	long long seconds_ms = static_cast<long long>(ui->timerSeconds->text().toInt()) * 1000;
 
 	return days_ms + hours_ms + minutes_ms + seconds_ms;
 }
 
-void AshmanixTimer::SendTimerTickEvent(QString timerId,
-				       long long timeLeftInMillis)
+void AshmanixTimer::SendTimerTickEvent(QString timerId, long long timeLeftInMillis)
 {
 	obs_data_t *eventData = obs_data_create();
 
 	// Convert milliseconds to readable format
-	QString timeString = ConvertDateTimeToFormattedDisplayString(
-		timeLeftInMillis, countdownTimerData.showLeadingZero);
+	QString timeString =
+		ConvertDateTimeToFormattedDisplayString(timeLeftInMillis, countdownTimerData.showLeadingZero);
 
-	obs_data_set_string(eventData, "timer_id",
-			    timerId.toStdString().c_str());
-	obs_data_set_string(eventData, "time_display",
-			    timeString.toStdString().c_str());
+	obs_data_set_string(eventData, "timer_id", timerId.toStdString().c_str());
+	obs_data_set_string(eventData, "time_display", timeString.toStdString().c_str());
 	obs_data_set_int(eventData, "time_left_ms", timeLeftInMillis);
 
 	emit RequestSendWebsocketEvent("const char *eventName", eventData);
@@ -653,14 +628,11 @@ void AshmanixTimer::SendTimerTickEvent(QString timerId,
 void AshmanixTimer::SendTimerStateEvent(QString timerId, const char *state)
 {
 	obs_data_t *eventData = obs_data_create();
-	obs_data_set_string(eventData, "timer_id",
-			    timerId.toStdString().c_str());
+	obs_data_set_string(eventData, "timer_id", timerId.toStdString().c_str());
 	obs_data_set_string(eventData, "state", state);
 
 	if (countdownTimerData.selectedSource.length() > 0) {
-		obs_data_set_string(
-			eventData, "text_source",
-			countdownTimerData.selectedSource.toStdString().c_str());
+		obs_data_set_string(eventData, "text_source", countdownTimerData.selectedSource.toStdString().c_str());
 	}
 
 	emit RequestSendWebsocketEvent("timer_state_changed", eventData);
@@ -671,78 +643,52 @@ void AshmanixTimer::RegisterAllHotkeys(obs_data_t *savedData)
 {
 	LoadHotkey(
 		countdownTimerData.startCountdownHotkeyId, TIMERSTARTHOTKEYNAME,
-		GetFullHotkeyName(
-			obs_module_text("StartCountdownHotkeyDescription"),
-			" - ")
-			.c_str(),
-		[this]() { ui->playButton->click(); },
-		GetFullHotkeyName("Play Hotkey Pressed", " "), savedData);
+		GetFullHotkeyName(obs_module_text("StartCountdownHotkeyDescription"), " - ").c_str(),
+		[this]() { ui->playButton->click(); }, GetFullHotkeyName("Play Hotkey Pressed", " "), savedData);
 
 	LoadHotkey(
 		countdownTimerData.pauseCountdownHotkeyId, TIMERPAUSEHOTKEYNAME,
-		GetFullHotkeyName(
-			obs_module_text("PauseCountdownHotkeyDescription"),
-			" - ")
-			.c_str(),
-		[this]() { ui->pauseButton->animateClick(); },
-		GetFullHotkeyName("Pause Hotkey Pressed", " "), savedData);
+		GetFullHotkeyName(obs_module_text("PauseCountdownHotkeyDescription"), " - ").c_str(),
+		[this]() { ui->pauseButton->animateClick(); }, GetFullHotkeyName("Pause Hotkey Pressed", " "),
+		savedData);
 
 	LoadHotkey(
 		countdownTimerData.setCountdownHotkeyId, TIMERSETHOTKEYNAME,
-		GetFullHotkeyName(
-			obs_module_text("SetCountdownHotkeyDescription"), " - ")
-			.c_str(),
-		[this]() { ui->resetButton->animateClick(); },
-		GetFullHotkeyName("Set Hotkey Pressed", " "), savedData);
+		GetFullHotkeyName(obs_module_text("SetCountdownHotkeyDescription"), " - ").c_str(),
+		[this]() { ui->resetButton->animateClick(); }, GetFullHotkeyName("Set Hotkey Pressed", " "), savedData);
 
 	LoadHotkey(
-		countdownTimerData.startCountdownToTimeHotkeyId,
-		TIMERTOTIMESTARTHOTKEYNAME,
-		GetFullHotkeyName(
-			obs_module_text("StartCountdownToTimeHotkeyDescription"),
-			" - ")
-			.c_str(),
+		countdownTimerData.startCountdownToTimeHotkeyId, TIMERTOTIMESTARTHOTKEYNAME,
+		GetFullHotkeyName(obs_module_text("StartCountdownToTimeHotkeyDescription"), " - ").c_str(),
 		[this]() { ui->toTimePlayButton->animateClick(); },
-		GetFullHotkeyName("To Time Start Hotkey Pressed", " "),
-		savedData);
+		GetFullHotkeyName("To Time Start Hotkey Pressed", " "), savedData);
 
 	LoadHotkey(
-		countdownTimerData.stopCountdownToTimeHotkeyId,
-		TIMERTOTIMESTOPHOTKEYNAME,
-		GetFullHotkeyName(
-			obs_module_text("StopCountdownToTimeHotkeyDescription"),
-			" - ")
-			.c_str(),
+		countdownTimerData.stopCountdownToTimeHotkeyId, TIMERTOTIMESTOPHOTKEYNAME,
+		GetFullHotkeyName(obs_module_text("StopCountdownToTimeHotkeyDescription"), " - ").c_str(),
 		[this]() { ui->toTimeStopButton->animateClick(); },
-		GetFullHotkeyName("To Time Stop Hotkey Pressed", " "),
-		savedData);
+		GetFullHotkeyName("To Time Stop Hotkey Pressed", " "), savedData);
 }
 
 void AshmanixTimer::UnregisterAllHotkeys()
 {
 	if (countdownTimerData.startCountdownHotkeyId)
-		obs_hotkey_unregister(
-			countdownTimerData.startCountdownHotkeyId);
+		obs_hotkey_unregister(countdownTimerData.startCountdownHotkeyId);
 	if (countdownTimerData.pauseCountdownHotkeyId)
-		obs_hotkey_unregister(
-			countdownTimerData.pauseCountdownHotkeyId);
+		obs_hotkey_unregister(countdownTimerData.pauseCountdownHotkeyId);
 	if (countdownTimerData.setCountdownHotkeyId)
 		obs_hotkey_unregister(countdownTimerData.setCountdownHotkeyId);
 
 	if (countdownTimerData.startCountdownToTimeHotkeyId)
-		obs_hotkey_unregister(
-			countdownTimerData.startCountdownToTimeHotkeyId);
+		obs_hotkey_unregister(countdownTimerData.startCountdownToTimeHotkeyId);
 	if (countdownTimerData.stopCountdownToTimeHotkeyId)
-		obs_hotkey_unregister(
-			countdownTimerData.stopCountdownToTimeHotkeyId);
+		obs_hotkey_unregister(countdownTimerData.stopCountdownToTimeHotkeyId);
 }
 
-std::string AshmanixTimer::GetFullHotkeyName(std::string name,
-					     const char *joinText)
+std::string AshmanixTimer::GetFullHotkeyName(std::string name, const char *joinText)
 {
 	static std::string fullName;
-	fullName = std::string(name) + std::string(joinText) +
-		   countdownTimerData.timerId.toStdString();
+	fullName = std::string(name) + std::string(joinText) + countdownTimerData.timerId.toStdString();
 	return fullName;
 }
 
@@ -759,16 +705,13 @@ void AshmanixTimer::PlayButtonClicked()
 	QDateTime currentDateTime = QDateTime::currentDateTime();
 
 	if ((!countdownTimerData.shouldCountUp && IsSetTimeZero()) ||
-	    (countdownTimerData.shouldCountUp &&
-	     countdownTimerData.timeLeftInMillis >= periodUIInMillis))
+	    (countdownTimerData.shouldCountUp && countdownTimerData.timeLeftInMillis >= periodUIInMillis))
 		return;
 
 	if (countdownTimerData.shouldCountUp) {
-		countdownTimerData.timeAtTimerStart = currentDateTime.addMSecs(
-			-(countdownTimerData.timeLeftInMillis));
+		countdownTimerData.timeAtTimerStart = currentDateTime.addMSecs(-(countdownTimerData.timeLeftInMillis));
 	} else {
-		countdownTimerData.timeAtTimerStart = currentDateTime.addMSecs(
-			countdownTimerData.timeLeftInMillis);
+		countdownTimerData.timeAtTimerStart = currentDateTime.addMSecs(countdownTimerData.timeLeftInMillis);
 	}
 
 	StartTimerCounting();
@@ -791,9 +734,8 @@ void AshmanixTimer::ResetButtonClicked()
 	}
 
 	StopTimerCounting();
-	countdownTimerData.shouldCountUp
-		? countdownTimerData.timeLeftInMillis = 0
-		: countdownTimerData.timeLeftInMillis = GetMillisFromPeriodUI();
+	countdownTimerData.shouldCountUp ? countdownTimerData.timeLeftInMillis = 0
+					 : countdownTimerData.timeLeftInMillis = GetMillisFromPeriodUI();
 
 	UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
 }
@@ -810,8 +752,7 @@ void AshmanixTimer::ToTimePlayButtonClicked()
 		countdownTimerData.timeLeftInMillis = 0;
 	} else {
 		countdownTimerData.timeLeftInMillis =
-			countdownTimerData.timeAtTimerStart.msecsTo(
-				ui->dateTimeEdit->dateTime());
+			countdownTimerData.timeAtTimerStart.msecsTo(ui->dateTimeEdit->dateTime());
 		if (countdownTimerData.timeLeftInMillis < 0)
 			countdownTimerData.timeLeftInMillis = 0;
 	}
@@ -834,11 +775,9 @@ void AshmanixTimer::ToTimeStopButtonClicked()
 void AshmanixTimer::SettingsButtonClicked()
 {
 	if (!settingsDialogUi) {
-		settingsDialogUi = new SettingsDialog(this, &countdownTimerData,
-						      mainDockWidget);
+		settingsDialogUi = new SettingsDialog(this, &countdownTimerData, mainDockWidget);
 
-		QObject::connect(settingsDialogUi,
-				 &SettingsDialog::SettingsUpdated, this,
+		QObject::connect(settingsDialogUi, &SettingsDialog::SettingsUpdated, this,
 				 [this]() { UpdateTimeDisplayTooltip(); });
 	}
 	if (settingsDialogUi->isVisible()) {
@@ -866,13 +805,11 @@ void AshmanixTimer::TimerAdjust()
 		if (countdownTimerData.selectedCountdownType == PERIOD) {
 			// If selected tab is period
 			timerPeriodMillis = static_cast<long long>(
-				QDateTime::currentDateTime().msecsTo(
-					countdownTimerData.timeAtTimerStart));
+				QDateTime::currentDateTime().msecsTo(countdownTimerData.timeAtTimerStart));
 		} else {
 			// If selected tab is datetime
 			timerPeriodMillis = static_cast<long long>(
-				QDateTime::currentDateTime().msecsTo(
-					ui->dateTimeEdit->dateTime()));
+				QDateTime::currentDateTime().msecsTo(ui->dateTimeEdit->dateTime()));
 		}
 		if (timerPeriodMillis < TIMERPERIOD)
 			endTimer = true;
@@ -882,18 +819,15 @@ void AshmanixTimer::TimerAdjust()
 		// Check if we need to end timer
 		if (countdownTimerData.selectedCountdownType == PERIOD) {
 			timerPeriodMillis = static_cast<long long>(
-				countdownTimerData.timeAtTimerStart.msecsTo(
-					QDateTime::currentDateTime()));
+				countdownTimerData.timeAtTimerStart.msecsTo(QDateTime::currentDateTime()));
 			// If selected tab is period
 			if (timerPeriodMillis >= GetMillisFromPeriodUI())
 				endTimer = true;
 		} else {
 			timerPeriodMillis = static_cast<long long>(
-				countdownTimerData.timeAtTimerStart.msecsTo(
-					QDateTime::currentDateTime()));
+				countdownTimerData.timeAtTimerStart.msecsTo(QDateTime::currentDateTime()));
 			// If selected tab is datetime
-			if ((countdownTimerData.timeAtTimerStart.msecsTo(
-				    ui->dateTimeEdit->dateTime())) -
+			if ((countdownTimerData.timeAtTimerStart.msecsTo(ui->dateTimeEdit->dateTime())) -
 				    timerPeriodMillis <=
 			    TIMERPERIOD)
 				endTimer = true;
@@ -906,23 +840,18 @@ void AshmanixTimer::TimerAdjust()
 		countdownTimerData.timeLeftInMillis = 0;
 
 	// We only update the time and send a tick event if the seconds have changed from last time
-	if (lastDisplayedSeconds !=
-	    (countdownTimerData.timeLeftInMillis / 1000)) {
-		lastDisplayedSeconds =
-			countdownTimerData.timeLeftInMillis / 1000;
+	if (lastDisplayedSeconds != (countdownTimerData.timeLeftInMillis / 1000)) {
+		lastDisplayedSeconds = countdownTimerData.timeLeftInMillis / 1000;
 
 		UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
 
 		// Send tick event
-		SendTimerTickEvent(countdownTimerData.timerId,
-				   countdownTimerData.timeLeftInMillis);
+		SendTimerTickEvent(countdownTimerData.timerId, countdownTimerData.timeLeftInMillis);
 	}
 
 	if (endTimer == true) {
 		if (countdownTimerData.showEndMessage) {
-			SetSourceText(
-				countdownTimerData.endMessage.toStdString()
-					.c_str());
+			SetSourceText(countdownTimerData.endMessage.toStdString().c_str());
 		}
 		if (countdownTimerData.showEndScene) {
 			SetCurrentScene();
@@ -931,18 +860,13 @@ void AshmanixTimer::TimerAdjust()
 			ui->timeDisplay->display(AshmanixTimer::ZEROSTRING);
 			countdownTimerData.timeLeftInMillis = 0;
 		} else {
-			if (countdownTimerData.selectedCountdownType ==
-			    PERIOD) {
-				countdownTimerData.timeLeftInMillis =
-					GetMillisFromPeriodUI();
+			if (countdownTimerData.selectedCountdownType == PERIOD) {
+				countdownTimerData.timeLeftInMillis = GetMillisFromPeriodUI();
 			} else {
 				countdownTimerData.timeLeftInMillis =
-					countdownTimerData.timeAtTimerStart
-						.msecsTo(ui->dateTimeEdit
-								 ->dateTime());
+					countdownTimerData.timeAtTimerStart.msecsTo(ui->dateTimeEdit->dateTime());
 			}
-			UpdateDateTimeDisplay(
-				countdownTimerData.timeLeftInMillis);
+			UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
 		}
 		// Send completion event
 		SendTimerStateEvent(countdownTimerData.timerId, "completed");
@@ -994,8 +918,7 @@ void AshmanixTimer::EmitMoveTimerUpSignal()
 
 void AshmanixTimer::ToggleTimeType(CountdownType type)
 {
-	if (countdownTimerData.periodVLayout &&
-	    countdownTimerData.datetimeVLayout) {
+	if (countdownTimerData.periodVLayout && countdownTimerData.datetimeVLayout) {
 		countdownTimerData.datetimeVLayout->hide();
 		countdownTimerData.periodVLayout->hide();
 		ui->periodToolButton->setChecked(false);
@@ -1011,8 +934,7 @@ void AshmanixTimer::ToggleTimeType(CountdownType type)
 			ui->datetimeToolButton->setChecked(true);
 		}
 	} else {
-		obs_log(LOG_WARNING,
-			"Period and/or Datetime layouts not found!");
+		obs_log(LOG_WARNING, "Period and/or Datetime layouts not found!");
 	}
 }
 

--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -225,7 +225,7 @@ bool AshmanixTimer::AddTime(const char *stringTime, bool isCountingUp)
 		result = true;
 	} else if (countdownTimerData.selectedCountdownType == DATETIME) {
 		QDateTime updatedDateTime;
-		updatedDateTime = ui->dateTimeEdit->dateTime().addMSecs(timeInMillis);
+		updatedDateTime = ui->dateTimeEdit->dateTime().addMSecs(timeInMillis + TIMERPERIOD);
 		ui->dateTimeEdit->setDateTime(updatedDateTime);
 		result = true;
 	}

--- a/src/widgets/ashmanix-timer.hpp
+++ b/src/widgets/ashmanix-timer.hpp
@@ -102,6 +102,7 @@ private:
 	void UpdateTimeDisplayTooltip();
 	bool AddTime(const char *stringTime, bool isCountingUp);
 	bool SetTime(const char *stringTime, bool isCountingUp);
+	void UpdateTimerPeriod(PeriodData periodData);
 
 signals:
 	void RequestTimerReset();

--- a/src/widgets/ashmanix-timer.hpp
+++ b/src/widgets/ashmanix-timer.hpp
@@ -1,6 +1,8 @@
 #ifndef ASHMANIXTIMER_H
 #define ASHMANIXTIMER_H
 
+#include <algorithm>
+
 #include <QWidget>
 #include <QDateTime>
 #include <QTabWidget>
@@ -31,10 +33,8 @@ class AshmanixTimer : public QWidget {
 	Q_OBJECT
 
 public:
-	explicit AshmanixTimer(QWidget *parent = nullptr,
-			       obs_websocket_vendor vendor = nullptr,
-			       obs_data_t *savedData = nullptr,
-			       CountdownDockWidget *mDockWidget = nullptr);
+	explicit AshmanixTimer(QWidget *parent = nullptr, obs_websocket_vendor vendor = nullptr,
+			       obs_data_t *savedData = nullptr, CountdownDockWidget *mDockWidget = nullptr);
 	~AshmanixTimer();
 
 	void SaveTimerWidgetDataToOBSSaveData(obs_data_t *dataObject);
@@ -47,8 +47,7 @@ public:
 	void SetIsUpButtonDisabled(bool isDisabled);
 	void SetIsDownButtonDisabled(bool isDisabled);
 	void SetTimerData();
-	bool AlterTime(WebsocketRequestType requestType,
-		       long long timeInMillis);
+	bool AlterTime(WebsocketRequestType requestType, const char *stringTime);
 
 	void PressPlayButton();
 	void PressResetButton();
@@ -68,16 +67,11 @@ private:
 	QSpacerItem *deleteButtonSpacer;
 	CountdownDockWidget *mainDockWidget;
 
-	static inline const char *TIMERSTARTHOTKEYNAME =
-		"Ashmanix_Countdown_Timer_Start";
-	static inline const char *TIMERPAUSEHOTKEYNAME =
-		"Ashmanix_Countdown_Timer_Pause";
-	static inline const char *TIMERSETHOTKEYNAME =
-		"Ashmanix_Countdown_Timer_Set";
-	static inline const char *TIMERTOTIMESTARTHOTKEYNAME =
-		"Ashmanix_Countdown_Timer_To_Time_Start";
-	static inline const char *TIMERTOTIMESTOPHOTKEYNAME =
-		"Ashmanix_Countdown_Timer_To_Time_Stop";
+	static inline const char *TIMERSTARTHOTKEYNAME = "Ashmanix_Countdown_Timer_Start";
+	static inline const char *TIMERPAUSEHOTKEYNAME = "Ashmanix_Countdown_Timer_Pause";
+	static inline const char *TIMERSETHOTKEYNAME = "Ashmanix_Countdown_Timer_Set";
+	static inline const char *TIMERTOTIMESTARTHOTKEYNAME = "Ashmanix_Countdown_Timer_To_Time_Start";
+	static inline const char *TIMERTOTIMESTOPHOTKEYNAME = "Ashmanix_Countdown_Timer_To_Time_Stop";
 
 	TimerWidgetStruct countdownTimerData;
 	Ui::AshmanixTimer *ui;
@@ -86,8 +80,7 @@ private:
 	void SetupTimerWidgetUI();
 	void ConnectUISignalHandlers();
 
-	QString ConvertDateTimeToFormattedDisplayString(long long timeInMillis,
-							bool showLeadingZero);
+	QString ConvertDateTimeToFormattedDisplayString(long long timeInMillis, bool showLeadingZero);
 	void StartTimerCounting();
 	void StopTimerCounting();
 	void InitialiseTimerTime();
@@ -104,16 +97,16 @@ private:
 	void RegisterAllHotkeys(obs_data_t *saved_data);
 	void UnregisterAllHotkeys();
 
-	std::string GetFullHotkeyName(std::string nameString,
-				      const char *joinText = "_");
+	std::string GetFullHotkeyName(std::string nameString, const char *joinText = "_");
 
 	void UpdateTimeDisplayTooltip();
+	bool AddTime(const char *stringTime, bool isCountingUp);
+	bool SetTime(const char *stringTime, bool isCountingUp);
 
 signals:
 	void RequestTimerReset();
 	void RequestDelete(QString id);
-	void RequestSendWebsocketEvent(const char *eventName,
-				       obs_data_t *eventData);
+	void RequestSendWebsocketEvent(const char *eventName, obs_data_t *eventData);
 	void MoveTimer(QString direction, QString timerId);
 
 public slots:

--- a/src/widgets/ashmanix-timer.hpp
+++ b/src/widgets/ashmanix-timer.hpp
@@ -105,7 +105,7 @@ private:
 	void UpdateTimerPeriod(PeriodData periodData);
 
 signals:
-	void RequestTimerReset(bool restartOnly= false);
+	void RequestTimerReset(bool restartOnly = false);
 	void RequestDelete(QString id);
 	void RequestSendWebsocketEvent(const char *eventName, obs_data_t *eventData);
 	void MoveTimer(QString direction, QString timerId);

--- a/src/widgets/ashmanix-timer.hpp
+++ b/src/widgets/ashmanix-timer.hpp
@@ -105,7 +105,7 @@ private:
 	void UpdateTimerPeriod(PeriodData periodData);
 
 signals:
-	void RequestTimerReset();
+	void RequestTimerReset(bool restartOnly= false);
 	void RequestDelete(QString id);
 	void RequestSendWebsocketEvent(const char *eventName, obs_data_t *eventData);
 	void MoveTimer(QString direction, QString timerId);
@@ -123,7 +123,7 @@ private slots:
 	void DeleteButtonClicked();
 
 	void TimerAdjust();
-	void HandleTimerReset();
+	void HandleTimerReset(bool restartOnly = false);
 
 	void DaysChanged(QString newText);
 	void HoursChanged(QString newText);

--- a/src/widgets/obs-dock-wrapper.hpp
+++ b/src/widgets/obs-dock-wrapper.hpp
@@ -8,11 +8,7 @@ class OBSDock : public QWidget {
 	Q_OBJECT
 
 public:
-	inline OBSDock(const QString &title, QWidget *parent = nullptr)
-		: QWidget(parent)
-	{
-		UNUSED_PARAMETER(title);
-	}
+	inline OBSDock(const QString &title, QWidget *parent = nullptr) : QWidget(parent) { UNUSED_PARAMETER(title); }
 
 	inline OBSDock(QWidget *parent = nullptr) : QWidget(parent) {}
 };

--- a/src/widgets/settings-dialog.cpp
+++ b/src/widgets/settings-dialog.cpp
@@ -1,7 +1,6 @@
 #include "settings-dialog.hpp"
 
-SettingsDialog::SettingsDialog(QWidget *parent, TimerWidgetStruct *tData,
-			       CountdownDockWidget *mWidget)
+SettingsDialog::SettingsDialog(QWidget *parent, TimerWidgetStruct *tData, CountdownDockWidget *mWidget)
 	: QDialog(parent),
 	  ui(new Ui::SettingsDialog)
 {
@@ -21,12 +20,9 @@ SettingsDialog::SettingsDialog(QWidget *parent, TimerWidgetStruct *tData,
 SettingsDialog::~SettingsDialog()
 {
 	// Disconnect OBS signals before the dialog is destroyed
-	signal_handler_disconnect(obs_get_signal_handler(), "source_create",
-				  OBSSourceCreated, ui);
-	signal_handler_disconnect(obs_get_signal_handler(), "source_destroy",
-				  OBSSourceDeleted, ui);
-	signal_handler_disconnect(obs_get_signal_handler(), "source_rename",
-				  OBSSourceRenamed, ui);
+	signal_handler_disconnect(obs_get_signal_handler(), "source_create", OBSSourceCreated, ui);
+	signal_handler_disconnect(obs_get_signal_handler(), "source_destroy", OBSSourceDeleted, ui);
+	signal_handler_disconnect(obs_get_signal_handler(), "source_rename", OBSSourceRenamed, ui);
 
 	this->deleteLater();
 }
@@ -51,67 +47,49 @@ void SettingsDialog::SetupDialogUI(TimerWidgetStruct *settingsDialogData)
 	ui->secondsCheckBox->setToolTip(obs_module_text("SecondsCheckBoxTip"));
 
 	ui->leadZeroCheckBox->setText(obs_module_text("LeadZeroCheckboxLabel"));
-	ui->leadZeroCheckBox->setToolTip(
-		obs_module_text("LeadZeroCheckBoxTip"));
+	ui->leadZeroCheckBox->setToolTip(obs_module_text("LeadZeroCheckBoxTip"));
 
 	ui->countUpCheckBox->setText(obs_module_text("CountUpCheckBoxLabel"));
 	ui->countUpCheckBox->setToolTip(obs_module_text("CountUpCheckBoxTip"));
 
-	ui->startOnStreamStartCheckBox->setText(
-		obs_module_text("StartOnStreamCheckBoxLabel"));
-	ui->startOnStreamStartCheckBox->setToolTip(
-		obs_module_text("StartOnStreamCheckBoxTip"));
+	ui->startOnStreamStartCheckBox->setText(obs_module_text("StartOnStreamCheckBoxLabel"));
+	ui->startOnStreamStartCheckBox->setToolTip(obs_module_text("StartOnStreamCheckBoxTip"));
 
 	ui->timerIdLineEdit->setToolTip(obs_module_text("timerIdLineEditTip"));
 	ui->timerIdLabel->setText(obs_module_text("TimerIdLabel"));
 
-	ui->textSourceDropdownList->setToolTip(
-		obs_module_text("TextSourceDropdownTip"));
+	ui->textSourceDropdownList->setToolTip(obs_module_text("TextSourceDropdownTip"));
 	ui->textSourceDropdownList->addItem("");
-	ui->textSourceDropdownLabel->setText(
-		obs_module_text("TextSourceLabel"));
+	ui->textSourceDropdownLabel->setText(obs_module_text("TextSourceLabel"));
 
 	ui->endMessageCheckBox->setCheckState(Qt::Unchecked);
-	ui->endMessageCheckBox->setToolTip(
-		obs_module_text("EndMessageCheckBoxTip"));
+	ui->endMessageCheckBox->setToolTip(obs_module_text("EndMessageCheckBoxTip"));
 	ui->endMessageCheckBox->setText(obs_module_text("EndMessageLabel"));
 
 	ui->endMessageLineEdit->setEnabled(false);
-	ui->endMessageLineEdit->setToolTip(
-		obs_module_text("EndMessageLineEditTip"));
+	ui->endMessageLineEdit->setToolTip(obs_module_text("EndMessageLineEditTip"));
 
 	ui->switchSceneCheckBox->setCheckState(Qt::Unchecked);
-	ui->switchSceneCheckBox->setToolTip(
-		obs_module_text("SwitchSceneCheckBoxTip"));
+	ui->switchSceneCheckBox->setToolTip(obs_module_text("SwitchSceneCheckBoxTip"));
 	ui->switchSceneCheckBox->setText(obs_module_text("SwitchScene"));
 
 	ui->sceneSourceDropdownList->setEnabled(false);
-	ui->sceneSourceDropdownList->setToolTip(
-		obs_module_text("SceneSourceDropdownTip"));
+	ui->sceneSourceDropdownList->setToolTip(obs_module_text("SceneSourceDropdownTip"));
 	ui->sceneSourceDropdownList->addItem("");
 
-	ui->generalGroupBox->setTitle(
-		obs_module_text("DialogGeneralGroupBoxTitle"));
-	ui->timerStartGroupBox->setTitle(
-		obs_module_text("DialogTimerStartGroupBoxTitle"));
-	ui->timerEndGroupBox->setTitle(
-		obs_module_text("DialogTimerEndGroupBoxTitle"));
-	ui->timeFormatGroupBox->setTitle(
-		obs_module_text("DialogTimeFormatGroupBoxTitle"));
-	ui->timerTypeGroupBox->setTitle(
-		obs_module_text("DialogTimerTypeGroupBoxTitle"));
+	ui->generalGroupBox->setTitle(obs_module_text("DialogGeneralGroupBoxTitle"));
+	ui->timerStartGroupBox->setTitle(obs_module_text("DialogTimerStartGroupBoxTitle"));
+	ui->timerEndGroupBox->setTitle(obs_module_text("DialogTimerEndGroupBoxTitle"));
+	ui->timeFormatGroupBox->setTitle(obs_module_text("DialogTimeFormatGroupBoxTitle"));
+	ui->timerTypeGroupBox->setTitle(obs_module_text("DialogTimerTypeGroupBoxTitle"));
 
 	ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
-	ui->dialogButtonBox->button(QDialogButtonBox::Apply)
-		->setText(obs_module_text("DialogButtonApplyLabel"));
-	ui->dialogButtonBox->button(QDialogButtonBox::Ok)
-		->setText(obs_module_text("DialogButtonOkLabel"));
-	ui->dialogButtonBox->button(QDialogButtonBox::Cancel)
-		->setText(obs_module_text("DialogButtonCancelLabel"));
+	ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setText(obs_module_text("DialogButtonApplyLabel"));
+	ui->dialogButtonBox->button(QDialogButtonBox::Ok)->setText(obs_module_text("DialogButtonOkLabel"));
+	ui->dialogButtonBox->button(QDialogButtonBox::Cancel)->setText(obs_module_text("DialogButtonCancelLabel"));
 
 	ui->byLabel->setText(obs_module_text("DialogInfoByLabel"));
-	ui->contributorsLabel->setText(
-		obs_module_text("DialogInfoConstributorsLabel"));
+	ui->contributorsLabel->setText(obs_module_text("DialogInfoConstributorsLabel"));
 	ui->versionLabel->setText(obs_module_text("DialogInfoVersionLabel"));
 	ui->versionTextLabel->setText(PLUGIN_VERSION);
 
@@ -129,8 +107,7 @@ void SettingsDialog::GetOBSSourceList()
 	char **sceneList = obs_frontend_get_scene_names();
 
 	if (sceneList == nullptr) {
-		obs_log(LOG_INFO,
-			"No scenes found or failed to retrieve scenes");
+		obs_log(LOG_INFO, "No scenes found or failed to retrieve scenes");
 		return;
 	}
 
@@ -143,59 +120,44 @@ void SettingsDialog::GetOBSSourceList()
 
 void SettingsDialog::ConnectUISignalHandlers()
 {
-	QObject::connect(ui->timerIdLineEdit, &QLineEdit::textChanged, this,
+	QObject::connect(ui->timerIdLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
+
+	QObject::connect(ui->textSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->textSourceDropdownList,
-			 &QComboBox::currentTextChanged, this,
+	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::stateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->startOnStreamStartCheckBox,
-			 &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::SceneSwitchCheckBoxSelected);
 
-	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::stateChanged,
-			 this, &SettingsDialog::SceneSwitchCheckBoxSelected);
-
-	QObject::connect(ui->sceneSourceDropdownList,
-			 &QComboBox::currentTextChanged, this,
+	QObject::connect(ui->sceneSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->endMessageCheckBox, &QCheckBox::stateChanged, this,
 			 &SettingsDialog::EndMessageCheckBoxSelected);
 
-	QObject::connect(ui->endMessageLineEdit, &QLineEdit::textChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->endMessageLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->daysCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->daysCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->hoursCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->hoursCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->minutesCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->minutesCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->secondsCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->secondsCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->countUpCheckBox, &QCheckBox::stateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->countUpCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::accepted, this,
-			 &SettingsDialog::OkButtonClicked);
+	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::OkButtonClicked);
 
-	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, this,
-			 &SettingsDialog::CancelButtonClicked);
+	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, this, &SettingsDialog::CancelButtonClicked);
 
-	QPushButton *applyButton =
-		ui->dialogButtonBox->button(QDialogButtonBox::Apply);
+	QPushButton *applyButton = ui->dialogButtonBox->button(QDialogButtonBox::Apply);
 	if (applyButton) {
-		connect(applyButton, &QPushButton::clicked, this,
-			&SettingsDialog::ApplyButtonClicked);
+		connect(applyButton, &QPushButton::clicked, this, &SettingsDialog::ApplyButtonClicked);
 	}
 }
 
@@ -221,14 +183,11 @@ bool SettingsDialog::GetTextSources(void *list_property, obs_source_t *source)
 void SettingsDialog::ConnectObsSignalHandlers()
 {
 	// Source Signals
-	signal_handler_connect(obs_get_signal_handler(), "source_create",
-			       OBSSourceCreated, ui);
+	signal_handler_connect(obs_get_signal_handler(), "source_create", OBSSourceCreated, ui);
 
-	signal_handler_connect(obs_get_signal_handler(), "source_destroy",
-			       OBSSourceDeleted, ui);
+	signal_handler_connect(obs_get_signal_handler(), "source_destroy", OBSSourceDeleted, ui);
 
-	signal_handler_connect(obs_get_signal_handler(), "source_rename",
-			       OBSSourceRenamed, ui);
+	signal_handler_connect(obs_get_signal_handler(), "source_rename", OBSSourceRenamed, ui);
 }
 
 void SettingsDialog::ApplyFormChanges()
@@ -238,38 +197,28 @@ void SettingsDialog::ApplyFormChanges()
 		QLineEdit *idLineEdit = ui->timerIdLineEdit;
 		QString setTImerId = idLineEdit->text();
 		if ((setTImerId != timerData->timerId && mainWidget)) {
-			Result updateIdResult = mainWidget->UpdateTimerList(
-				timerData->timerId, setTImerId);
+			Result updateIdResult = mainWidget->UpdateTimerList(timerData->timerId, setTImerId);
 			if (updateIdResult.success == true) {
 				idLineEdit->setStyleSheet("");
-				QString dialogTitle =
-					QString("Timer %1").arg(setTImerId);
+				QString dialogTitle = QString("Timer %1").arg(setTImerId);
 				this->setWindowTitle(dialogTitle);
 			} else {
 				// Show popup with error
 				isError = true;
-				idLineEdit->setStyleSheet(
-					"border: 1px solid rgb(192, 0, 0);");
-				obs_log(LOG_WARNING, updateIdResult.errorMessage
-							     .toStdString()
-							     .c_str());
-				QMessageBox::warning(
-					this, ui->timerIdLabel->text(),
-					updateIdResult.errorMessage);
+				idLineEdit->setStyleSheet("border: 1px solid rgb(192, 0, 0);");
+				obs_log(LOG_WARNING, updateIdResult.errorMessage.toStdString().c_str());
+				QMessageBox::warning(this, ui->timerIdLabel->text(), updateIdResult.errorMessage);
 				return;
 			}
 		}
-		timerData->selectedSource =
-			ui->textSourceDropdownList->currentText();
+		timerData->selectedSource = ui->textSourceDropdownList->currentText();
 
-		timerData->startOnStreamStart =
-			ui->startOnStreamStartCheckBox->isChecked();
+		timerData->startOnStreamStart = ui->startOnStreamStartCheckBox->isChecked();
 
 		timerData->showEndMessage = ui->endMessageCheckBox->isChecked();
 		timerData->endMessage = ui->endMessageLineEdit->text();
 		timerData->showEndScene = ui->switchSceneCheckBox->isChecked();
-		timerData->selectedScene =
-			ui->sceneSourceDropdownList->currentText();
+		timerData->selectedScene = ui->sceneSourceDropdownList->currentText();
 
 		timerData->showDays = ui->daysCheckBox->isChecked();
 		timerData->showHours = ui->hoursCheckBox->isChecked();
@@ -279,8 +228,7 @@ void SettingsDialog::ApplyFormChanges()
 
 		timerData->shouldCountUp = ui->countUpCheckBox->isChecked();
 
-		ui->dialogButtonBox->button(QDialogButtonBox::Apply)
-			->setEnabled(false);
+		ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 		emit SettingsUpdated();
 	} else {
 		obs_log(LOG_WARNING, "No timer data found!");
@@ -292,48 +240,34 @@ void SettingsDialog::SetFormDetails(TimerWidgetStruct *settingsDialogData)
 	if (settingsDialogData != nullptr) {
 		ui->timerIdLineEdit->setText(settingsDialogData->timerId);
 
-		int textSelectIndex = ui->textSourceDropdownList->findText(
-			settingsDialogData->selectedSource);
+		int textSelectIndex = ui->textSourceDropdownList->findText(settingsDialogData->selectedSource);
 		if (textSelectIndex != -1)
-			ui->textSourceDropdownList->setCurrentIndex(
-				textSelectIndex);
+			ui->textSourceDropdownList->setCurrentIndex(textSelectIndex);
 
-		ui->startOnStreamStartCheckBox->setChecked(
-			settingsDialogData->startOnStreamStart);
+		ui->startOnStreamStartCheckBox->setChecked(settingsDialogData->startOnStreamStart);
 
-		int sceneSelectIndex = ui->sceneSourceDropdownList->findText(
-			settingsDialogData->selectedScene);
+		int sceneSelectIndex = ui->sceneSourceDropdownList->findText(settingsDialogData->selectedScene);
 		if (sceneSelectIndex != -1)
-			ui->sceneSourceDropdownList->setCurrentIndex(
-				sceneSelectIndex);
+			ui->sceneSourceDropdownList->setCurrentIndex(sceneSelectIndex);
 
 		ui->daysCheckBox->setChecked(settingsDialogData->showDays);
 		ui->hoursCheckBox->setChecked(settingsDialogData->showHours);
-		ui->minutesCheckBox->setChecked(
-			settingsDialogData->showMinutes);
-		ui->secondsCheckBox->setChecked(
-			settingsDialogData->showSeconds);
-		ui->leadZeroCheckBox->setChecked(
-			settingsDialogData->showLeadingZero);
+		ui->minutesCheckBox->setChecked(settingsDialogData->showMinutes);
+		ui->secondsCheckBox->setChecked(settingsDialogData->showSeconds);
+		ui->leadZeroCheckBox->setChecked(settingsDialogData->showLeadingZero);
 
-		ui->countUpCheckBox->setChecked(
-			settingsDialogData->shouldCountUp);
+		ui->countUpCheckBox->setChecked(settingsDialogData->shouldCountUp);
 		if (settingsDialogData->isPlaying)
 			ui->countUpCheckBox->setEnabled(false);
 
-		ui->endMessageCheckBox->setChecked(
-			settingsDialogData->showEndMessage);
-		ui->endMessageLineEdit->setEnabled(
-			settingsDialogData->showEndMessage);
+		ui->endMessageCheckBox->setChecked(settingsDialogData->showEndMessage);
+		ui->endMessageLineEdit->setEnabled(settingsDialogData->showEndMessage);
 		ui->endMessageLineEdit->setText(settingsDialogData->endMessage);
 
-		ui->switchSceneCheckBox->setChecked(
-			settingsDialogData->showEndScene);
-		ui->sceneSourceDropdownList->setEnabled(
-			settingsDialogData->showEndScene);
+		ui->switchSceneCheckBox->setChecked(settingsDialogData->showEndScene);
+		ui->sceneSourceDropdownList->setEnabled(settingsDialogData->showEndScene);
 
-		ui->dialogButtonBox->button(QDialogButtonBox::Apply)
-			->setEnabled(false);
+		ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 	} else {
 		obs_log(LOG_WARNING, "No timer data found!");
 	}
@@ -379,12 +313,10 @@ void SettingsDialog::OBSSourceDeleted(void *param, calldata_t *calldata)
 	const char *name = obs_source_get_name(source);
 
 	if (sourceType == TEXT_SOURCE) {
-		int textIndexToRemove =
-			ui->textSourceDropdownList->findText(name);
+		int textIndexToRemove = ui->textSourceDropdownList->findText(name);
 		ui->textSourceDropdownList->removeItem(textIndexToRemove);
 	} else if (sourceType == SCENE_SOURCE) {
-		int sceneIndexToRemove =
-			ui->sceneSourceDropdownList->findText(name);
+		int sceneIndexToRemove = ui->sceneSourceDropdownList->findText(name);
 		ui->sceneSourceDropdownList->removeItem(sceneIndexToRemove);
 	}
 };
@@ -407,26 +339,22 @@ void SettingsDialog::OBSSourceRenamed(void *param, calldata_t *calldata)
 	const char *oldName = calldata_string(calldata, "prev_name");
 
 	if (sourceType == TEXT_SOURCE) {
-		int textListIndex =
-			ui->textSourceDropdownList->findText(oldName);
+		int textListIndex = ui->textSourceDropdownList->findText(oldName);
 		if (textListIndex == -1)
 			return;
 		ui->textSourceDropdownList->setItemText(textListIndex, newName);
 	} else if (sourceType == SCENE_SOURCE) {
-		int sceneListIndex =
-			ui->sceneSourceDropdownList->findText(oldName);
+		int sceneListIndex = ui->sceneSourceDropdownList->findText(oldName);
 		if (sceneListIndex == -1)
 			return;
-		ui->sceneSourceDropdownList->setItemText(sceneListIndex,
-							 newName);
+		ui->sceneSourceDropdownList->setItemText(sceneListIndex, newName);
 	}
 };
 
 int SettingsDialog::CheckSourceType(obs_source_t *source)
 {
 	const char *source_id = obs_source_get_unversioned_id(source);
-	if (strcmp(source_id, "text_ft2_source") == 0 ||
-	    strcmp(source_id, "text_gdiplus") == 0 ||
+	if (strcmp(source_id, "text_ft2_source") == 0 || strcmp(source_id, "text_gdiplus") == 0 ||
 	    strcmp(source_id, "text_pango_source") == 0) {
 		return TEXT_SOURCE;
 	} else if (strcmp(source_id, "scene") == 0) {

--- a/src/widgets/settings-dialog.hpp
+++ b/src/widgets/settings-dialog.hpp
@@ -18,8 +18,7 @@ class SettingsDialog : public QDialog {
 	Q_OBJECT
 
 public:
-	explicit SettingsDialog(QWidget *parent = nullptr,
-				TimerWidgetStruct *tData = nullptr,
+	explicit SettingsDialog(QWidget *parent = nullptr, TimerWidgetStruct *tData = nullptr,
 				CountdownDockWidget *mWidget = nullptr);
 	~SettingsDialog();
 


### PR DESCRIPTION
Set Time and Add Time websocket features weren't working as expected. I have changed how these work now:

## Count Up
- Add Time will add time to the set period/datetime
- Set Time will set the time on period/datetime and reset the timer to zero.

## Count Down
- Add Time will add time to the timer and to the period/datetime set
- Set Time will set the time on period/datetime and reset the timer to that time.