### PR TITLE
fix: support qt6.8

### DIFF
--- a/src/widgets/settings-dialog.cpp
+++ b/src/widgets/settings-dialog.cpp
@@ -132,38 +132,38 @@ void SettingsDialog::ConnectUISignalHandlers()
 	QObject::connect(ui->textSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::SceneSwitchCheckBoxSelected);
 
 	QObject::connect(ui->sceneSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->endMessageCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::EndMessageCheckBoxSelected);
 
-	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormatOutputCheckBoxSelected);
 
 	QObject::connect(ui->formatOutputLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->endMessageLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->daysCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->daysCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->hoursCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->hoursCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->minutesCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->minutesCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->secondsCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->secondsCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->countUpCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->countUpCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::OkButtonClicked);


### PR DESCRIPTION
Hi,

Just made this change for the plugin build on my fedora, I'm not sure it supports versions older than qt 6.7.  probably have to set up alternative build systems.  Alternative build systems would probably have to be implemented.

