### PR TITLE
Added code to toggle the countdown type on load

### DIFF
--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -199,6 +199,8 @@ void AshmanixTimer::SetTimerData()
 
 	ui->timerNameLabel->setText(QString("Timer: %1").arg(countdownTimerData.timerId));
 
+	ToggleTimeType(countdownTimerData.selectedCountdownType);
+
 	UpdateDateTimeDisplay(countdownTimerData.timeLeftInMillis);
 	InitialiseTimerTime(false);
 }


### PR DESCRIPTION
This change fixes an issue where the plugin seemingly isn't saving and loading the countdown type last selected for each timer. It adds in a line on plugin load to use the saved data to toggle the countdown type.