### PR TITLE
Change state changed to check state changed

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.0.2",
+            "version": "30.1.2",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "74563ebbee5fcd448e6a790569cf3ca1a01bdcbc6bc2b3f61a9421ff8dfa6eb2",
-                "windows-x64": "e8434dcee06f1702f0a0bbd1489296c77116fc51356835c3af4a6ed21b1e1c74"
+                "macos": "490bae1c392b3b344b0270afd8cb887da4bc50bd92c0c426e96713c1ccb9701a",
+                "windows-x64": "c2dd03fa7fd01fad5beafce8f7156da11f9ed9a588373fd40b44a06f4c03b867"
             }
         },
         "prebuilt": {
-            "version": "2025-03-06",
+            "version": "2024-03-19",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "e32bd7dbfef37931147781d8d657a4328bdcf1148008980539c07d4a18b54965",
-                "windows-x64": "e62fdffb428d6ca32ce06eca3b1971c38b571ae095e7fe5bc6e3666a1e846c58"
+                "macos": "2e9bfb55a5e0e4c1086fa1fda4cf268debfead473089df2aaea80e1c7a3ca7ff",
+                "windows-x64": "6e86068371526a967e805f6f9903f9407adb683c21820db5f07da8f30d11e998"
             }
         },
         "qt6": {
-            "version": "2025-03-06",
+            "version": "2024-03-19",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "51bb5e2e546443ae442f74870a2c0973f1c07d2b5628cd1d530d53ff3f668f04",
-                "windows-x64": "84f83f1c3656b53a7c4ba8f8248818ba8684786e3e47123b679406e42d8b6a54"
+                "macos": "694f1e639c017e3b1f456f735330dc5afae287cbea85757101af1368de3142c8",
+                "windows-x64": "72d1df34a0ef7413a681d5fcc88cae81da60adc03dcd23ef17862ab170bcc0dd"
             },
             "debugSymbols": {
-                "windows-x64": "36bfa31109da5273e93e68faa62b0cf4a89092147c5203f1a17d2ec7d1c814b4"
+                "windows-x64": "fbddd1f659c360f2291911ac5709b67b6f8182e6bca519d24712e4f6fd3cc865"
             }
         }
     },

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "30.1.2",
+            "version": "31.0.2",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "490bae1c392b3b344b0270afd8cb887da4bc50bd92c0c426e96713c1ccb9701a",
-                "windows-x64": "c2dd03fa7fd01fad5beafce8f7156da11f9ed9a588373fd40b44a06f4c03b867"
+                "macos": "74563ebbee5fcd448e6a790569cf3ca1a01bdcbc6bc2b3f61a9421ff8dfa6eb2",
+                "windows-x64": "e8434dcee06f1702f0a0bbd1489296c77116fc51356835c3af4a6ed21b1e1c74"
             }
         },
         "prebuilt": {
-            "version": "2024-03-19",
+            "version": "2025-03-06",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "2e9bfb55a5e0e4c1086fa1fda4cf268debfead473089df2aaea80e1c7a3ca7ff",
-                "windows-x64": "6e86068371526a967e805f6f9903f9407adb683c21820db5f07da8f30d11e998"
+                "macos": "e32bd7dbfef37931147781d8d657a4328bdcf1148008980539c07d4a18b54965",
+                "windows-x64": "e62fdffb428d6ca32ce06eca3b1971c38b571ae095e7fe5bc6e3666a1e846c58"
             }
         },
         "qt6": {
-            "version": "2024-03-19",
+            "version": "2025-03-06",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "694f1e639c017e3b1f456f735330dc5afae287cbea85757101af1368de3142c8",
-                "windows-x64": "72d1df34a0ef7413a681d5fcc88cae81da60adc03dcd23ef17862ab170bcc0dd"
+                "macos": "51bb5e2e546443ae442f74870a2c0973f1c07d2b5628cd1d530d53ff3f668f04",
+                "windows-x64": "84f83f1c3656b53a7c4ba8f8248818ba8684786e3e47123b679406e42d8b6a54"
             },
             "debugSymbols": {
-                "windows-x64": "fbddd1f659c360f2291911ac5709b67b6f8182e6bca519d24712e4f6fd3cc865"
+                "windows-x64": "36bfa31109da5273e93e68faa62b0cf4a89092147c5203f1a17d2ec7d1c814b4"
             }
         }
     },

--- a/src/widgets/settings-dialog.cpp
+++ b/src/widgets/settings-dialog.cpp
@@ -132,38 +132,39 @@ void SettingsDialog::ConnectUISignalHandlers()
 	QObject::connect(ui->textSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::SceneSwitchCheckBoxSelected);
 
 	QObject::connect(ui->sceneSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->endMessageCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::EndMessageCheckBoxSelected);
 
-	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormatOutputCheckBoxSelected);
 
 	QObject::connect(ui->formatOutputLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->endMessageLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->daysCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->daysCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->hoursCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->hoursCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->minutesCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->minutesCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->secondsCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->secondsCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->countUpCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->countUpCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::stateChanged, this,
+	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::OkButtonClicked);
@@ -403,9 +404,9 @@ void SettingsDialog::FormChangeDetected()
 	ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
-void SettingsDialog::EndMessageCheckBoxSelected(int state)
+void SettingsDialog::EndMessageCheckBoxSelected(Qt::CheckState state)
 {
-	if (state) {
+	if (state == Qt::CheckState::Checked) {
 		ui->endMessageLineEdit->setEnabled(true);
 	} else {
 		ui->endMessageLineEdit->setEnabled(false);
@@ -413,9 +414,9 @@ void SettingsDialog::EndMessageCheckBoxSelected(int state)
 	FormChangeDetected();
 }
 
-void SettingsDialog::SceneSwitchCheckBoxSelected(int state)
+void SettingsDialog::SceneSwitchCheckBoxSelected(Qt::CheckState state)
 {
-	if (state) {
+	if (state == Qt::CheckState::Checked) {
 		ui->sceneSourceDropdownList->setEnabled(true);
 	} else {
 		ui->sceneSourceDropdownList->setEnabled(false);
@@ -423,9 +424,9 @@ void SettingsDialog::SceneSwitchCheckBoxSelected(int state)
 	FormChangeDetected();
 }
 
-void SettingsDialog::FormatOutputCheckBoxSelected(int state)
+void SettingsDialog::FormatOutputCheckBoxSelected(Qt::CheckState state)
 {
-	if (state) {
+	if (state == Qt::CheckState::Checked) {
 		ui->formatOutputLineEdit->setEnabled(true);
 	} else {
 		ui->formatOutputLineEdit->setEnabled(false);

--- a/src/widgets/settings-dialog.cpp
+++ b/src/widgets/settings-dialog.cpp
@@ -132,40 +132,59 @@ void SettingsDialog::ConnectUISignalHandlers()
 	QObject::connect(ui->textSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
 
-	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::checkStateChanged, this,
-			 &SettingsDialog::FormChangeDetected);
-
-	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::checkStateChanged, this,
-			 &SettingsDialog::SceneSwitchCheckBoxSelected);
-
 	QObject::connect(ui->sceneSourceDropdownList, &QComboBox::currentTextChanged, this,
 			 &SettingsDialog::FormChangeDetected);
-
-	QObject::connect(ui->endMessageCheckBox, &QCheckBox::checkStateChanged, this,
-			 &SettingsDialog::EndMessageCheckBoxSelected);
-
-	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::checkStateChanged, this,
-			 &SettingsDialog::FormatOutputCheckBoxSelected);
 
 	QObject::connect(ui->formatOutputLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
 	QObject::connect(ui->endMessageLineEdit, &QLineEdit::textChanged, this, &SettingsDialog::FormChangeDetected);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::SceneSwitchCheckBoxSelected);
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::EndMessageCheckBoxSelected);
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::FormatOutputCheckBoxSelected);
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::EndMessageCheckBoxSelected);
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::checkStateChanged, this,
+			 &SettingsDialog::FormatOutputCheckBoxSelected);
+
 	QObject::connect(ui->daysCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->hoursCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->minutesCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->secondsCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->countUpCheckBox, &QCheckBox::checkStateChanged, this, &SettingsDialog::FormChangeDetected);
-
 	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::checkStateChanged, this,
 			 &SettingsDialog::FormChangeDetected);
+#else
+	QObject::connect(ui->startOnStreamStartCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->switchSceneCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::SceneSwitchCheckBoxSelected);
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::EndMessageCheckBoxSelected);
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::FormatOutputCheckBoxSelected);
+	QObject::connect(ui->endMessageCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::EndMessageCheckBoxSelected);
+	QObject::connect(ui->formatOutputCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::FormatOutputCheckBoxSelected);
+
+	QObject::connect(ui->daysCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->hoursCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->minutesCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->secondsCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->leadZeroCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->countUpCheckBox, &QCheckBox::stateChanged, this, &SettingsDialog::FormChangeDetected);
+	QObject::connect(ui->smoothPeriodTimerCheckBox, &QCheckBox::stateChanged, this,
+			 &SettingsDialog::FormChangeDetected);
+#endif
 
 	QObject::connect(ui->dialogButtonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::OkButtonClicked);
 
@@ -404,6 +423,8 @@ void SettingsDialog::FormChangeDetected()
 	ui->dialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+
 void SettingsDialog::EndMessageCheckBoxSelected(Qt::CheckState state)
 {
 	if (state == Qt::CheckState::Checked) {
@@ -433,6 +454,40 @@ void SettingsDialog::FormatOutputCheckBoxSelected(Qt::CheckState state)
 	}
 	FormChangeDetected();
 }
+
+#else
+
+void SettingsDialog::EndMessageCheckBoxSelected(int state)
+{
+	if (state) {
+		ui->endMessageLineEdit->setEnabled(true);
+	} else {
+		ui->endMessageLineEdit->setEnabled(false);
+	}
+	FormChangeDetected();
+}
+
+void SettingsDialog::SceneSwitchCheckBoxSelected(int state)
+{
+	if (state) {
+		ui->sceneSourceDropdownList->setEnabled(true);
+	} else {
+		ui->sceneSourceDropdownList->setEnabled(false);
+	}
+	FormChangeDetected();
+}
+
+void SettingsDialog::FormatOutputCheckBoxSelected(int state)
+{
+	if (state) {
+		ui->formatOutputLineEdit->setEnabled(true);
+	} else {
+		ui->formatOutputLineEdit->setEnabled(false);
+	}
+	FormChangeDetected();
+}
+
+#endif
 
 void SettingsDialog::ApplyButtonClicked()
 {

--- a/src/widgets/settings-dialog.hpp
+++ b/src/widgets/settings-dialog.hpp
@@ -53,9 +53,15 @@ signals:
 
 private slots:
 	void FormChangeDetected();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 	void EndMessageCheckBoxSelected(Qt::CheckState state);
 	void SceneSwitchCheckBoxSelected(Qt::CheckState state);
 	void FormatOutputCheckBoxSelected(Qt::CheckState state);
+#else
+	void EndMessageCheckBoxSelected(int state);
+	void SceneSwitchCheckBoxSelected(int state);
+	void FormatOutputCheckBoxSelected(int state);
+#endif
 	void ApplyButtonClicked();
 	void CancelButtonClicked();
 	void OkButtonClicked();

--- a/src/widgets/settings-dialog.hpp
+++ b/src/widgets/settings-dialog.hpp
@@ -53,9 +53,9 @@ signals:
 
 private slots:
 	void FormChangeDetected();
-	void EndMessageCheckBoxSelected(int state);
-	void SceneSwitchCheckBoxSelected(int state);
-	void FormatOutputCheckBoxSelected(int state);
+	void EndMessageCheckBoxSelected(Qt::CheckState state);
+	void SceneSwitchCheckBoxSelected(Qt::CheckState state);
+	void FormatOutputCheckBoxSelected(Qt::CheckState state);
 	void ApplyButtonClicked();
 	void CancelButtonClicked();
 	void OkButtonClicked();


### PR DESCRIPTION
To work around Linux packaging CI and after discussion in the OBS forum I have added in if statements to handle when a Qt version newer than 6.7 is used (where the `checkStateChanged` function becomes available). 

Note that when compiled with Qt 6.7 + this will not work with the current version of OBS (currently version 31.0.3) as OBS core uses Qt version 6.6.