### PR TITLE
 Add Time Webhook Fix For Period Timer using Smooth Period

### DIFF
--- a/src/widgets/ashmanix-timer.cpp
+++ b/src/widgets/ashmanix-timer.cpp
@@ -252,6 +252,10 @@ bool AshmanixTimer::AddTime(const char *stringTime, bool isCountingUp)
 
 	if (!isCountingUp) {
 		countdownTimerData.timeAtTimerStart = countdownTimerData.timeAtTimerStart.addMSecs(timeInMillis);
+		// If we are using the smooth period timer option then we need to set time left in millis
+		if (countdownTimerData.selectedCountdownType == PERIOD && countdownTimerData.smoothenPeriodTimer)
+			countdownTimerData.timeLeftInMillis = newTimeLeftInMillis;
+
 		UpdateDateTimeDisplay(newTimeLeftInMillis);
 		emit RequestTimerReset(true);
 	}


### PR DESCRIPTION
Fix that will ensure when time added to smooth period timer, time is actually added to timer as well as UI.

This addresses issue #134 